### PR TITLE
Fixes Windows related issues

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -19,8 +19,8 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/google/go-github/v24/github"
-	"github.com/reviewdog/errorformat/fmts"
 	shellwords "github.com/mattn/go-shellwords"
+	"github.com/reviewdog/errorformat/fmts"
 	"github.com/reviewdog/reviewdog"
 	"github.com/reviewdog/reviewdog/cienv"
 	"github.com/reviewdog/reviewdog/project"

--- a/cmd/reviewdog/main_test.go
+++ b/cmd/reviewdog/main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -50,7 +51,7 @@ line3
 		want = fname + "(2,1): message1"
 	)
 
-	diffCmd := fmt.Sprintf("diff -u %s %s", beforef.Name(), afterf.Name())
+	diffCmd := fmt.Sprintf("diff -u %s %s", filepath.ToSlash(beforef.Name()), filepath.ToSlash(afterf.Name()))
 
 	opt := &option{
 		diffCmd:   diffCmd,

--- a/filter.go
+++ b/filter.go
@@ -51,7 +51,7 @@ func CleanPath(path, workdir string) string {
 	if p == "." {
 		return ""
 	}
-	return p
+	return filepath.ToSlash(p)
 }
 
 // addedLine represents added line in diff.

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -55,7 +55,7 @@ func NewGitHubPullRequest(cli *github.Client, owner, repo string, pr int, sha st
 // Post accepts a comment and holds it. Flush method actually posts comments to
 // GitHub in parallel.
 func (g *GitHubPullRequest) Post(_ context.Context, c *reviewdog.Comment) error {
-	c.Path = filepath.Join(g.wd, c.Path)
+	c.Path = filepath.ToSlash(filepath.Join(g.wd, c.Path))
 	g.muComments.Lock()
 	defer g.muComments.Unlock()
 	g.postComments = append(g.postComments, c)

--- a/service/gitlab/gitlab_mr_commit.go
+++ b/service/gitlab/gitlab_mr_commit.go
@@ -55,7 +55,7 @@ func NewGitLabMergeRequestCommitCommenter(cli *gitlab.Client, owner, repo string
 // Post accepts a comment and holds it. Flush method actually posts comments to
 // GitLab in parallel.
 func (g *GitLabMergeRequestCommitCommenter) Post(_ context.Context, c *reviewdog.Comment) error {
-	c.Path = filepath.Join(g.wd, c.Path)
+	c.Path = filepath.ToSlash(filepath.Join(g.wd, c.Path))
 	g.muComments.Lock()
 	defer g.muComments.Unlock()
 	g.postComments = append(g.postComments, c)


### PR DESCRIPTION
Use filepath.ToSlash for local paths
```
ok  	github.com/reviewdog/reviewdog	(cached)
ok  	github.com/reviewdog/reviewdog/cienv	(cached)
ok  	github.com/reviewdog/reviewdog/cmd/reviewdog	(cached)
ok  	github.com/reviewdog/reviewdog/diff	(cached)
?   	github.com/reviewdog/reviewdog/doghouse	[no test files]
?   	github.com/reviewdog/reviewdog/doghouse/appengine	[no test files]
?   	github.com/reviewdog/reviewdog/doghouse/appengine/statik	[no test files]
ok  	github.com/reviewdog/reviewdog/doghouse/client	(cached)
ok  	github.com/reviewdog/reviewdog/doghouse/server	(cached)
ok  	github.com/reviewdog/reviewdog/doghouse/server/ciutil	(cached)
ok  	github.com/reviewdog/reviewdog/doghouse/server/cookieman	(cached)
?   	github.com/reviewdog/reviewdog/doghouse/server/storage	[no test files]
ok  	github.com/reviewdog/reviewdog/project	(cached)
ok  	github.com/reviewdog/reviewdog/service/github	1.337s
ok  	github.com/reviewdog/reviewdog/service/gitlab	2.334s
ok  	github.com/reviewdog/reviewdog/service/serviceutil	0.388s
```
