### PR TITLE
workaround for failing honnef.co/go/tools install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ install:
   # Install linters.
   - go get golang.org/x/lint/golint
   - go get github.com/kisielk/errcheck
-  - go get honnef.co/go/tools/cmd/gosimple
-  - go get honnef.co/go/tools/cmd/staticcheck
-  - go get honnef.co/go/tools/cmd/unused
+  - go get honnef.co/go/tools/cmd/gosimple@2019.1.1
+  - go get honnef.co/go/tools/cmd/staticcheck@2019.1.1
+  - go get honnef.co/go/tools/cmd/unused@2019.1.1
   - go get github.com/client9/misspell/cmd/misspell
   - go get mvdan.cc/unparam
   - go get github.com/mgechev/revive


### PR DESCRIPTION
workaround for https://github.com/reviewdog/reviewdog/pull/222#issuecomment-501131351

> https://travis-ci.org/reviewdog/reviewdog/jobs/544561733
> 
> installing honnef.co/go/tools/cmd/gosimple is failing. :(
> 
> ```
> $ go get honnef.co/go/tools/cmd/gosimple
> go: finding honnef.co/go/tools/cmd/gosimple latest
> go: finding honnef.co/go/tools latest
> go: downloading honnef.co/go/tools v0.0.0-20190607181801-497c8f037f5a
> go: extracting honnef.co/go/tools v0.0.0-20190607181801-497c8f037f5a
> go get honnef.co/go/tools/cmd/gosimple: module honnef.co/go/tools@latest (v0.0.0-20190607181801-497c8f037f5a) found, but does not contain package honnef.co/go/tools/cmd/gosimple
> The command "go get honnef.co/go/tools/cmd/gosimple" failed and exited with 1 during .
> ```