### PR TITLE
Remove BlobHRef from struct of github.CheckRunAnnotation

### DIFF
--- a/doghouse/server/doghouse.go
+++ b/doghouse/server/doghouse.go
@@ -205,7 +205,6 @@ func (ch *Checker) buildFindingLink(c *reviewdog.FilteredCheck) string {
 func (ch *Checker) toCheckRunAnnotation(c *reviewdog.FilteredCheck) *github.CheckRunAnnotation {
 	a := &github.CheckRunAnnotation{
 		Path:            github.String(c.Path),
-		BlobHRef:        github.String(ch.brobHRef(c.Path)),
 		StartLine:       github.Int(c.Lnum),
 		EndLine:         github.Int(c.Lnum),
 		AnnotationLevel: github.String(ch.annotationLevel()),

--- a/doghouse/server/doghouse_test.go
+++ b/doghouse/server/doghouse_test.go
@@ -117,7 +117,6 @@ func TestCheck_OK(t *testing.T) {
 		wantAnnotaions := []*github.CheckRunAnnotation{
 			{
 				Path:            github.String("sample.new.txt"),
-				BlobHRef:        github.String("http://github.com/haya14busa/reviewdog/blob/1414/sample.new.txt"),
 				StartLine:       github.Int(2),
 				EndLine:         github.Int(2),
 				AnnotationLevel: github.String("warning"),


### PR DESCRIPTION
# What 
I remove `BlobHRef` from struct of github.CheckRunAnnotation.

# Why
Because removed variable  in `go-github` repo. So I think It would be better to remove in this repo too.
FYI : https://github.com/google/go-github/pull/1242