### PR TITLE
Do not set CreateCheckRunOptions.HeadBranch

### DIFF
--- a/doghouse/server/github_checker.go
+++ b/doghouse/server/github_checker.go
@@ -7,18 +7,12 @@ import (
 )
 
 type checkerGitHubClientInterface interface {
-	GetPullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error)
 	GetPullRequestDiff(ctx context.Context, owner, repo string, number int) ([]byte, error)
 	CreateCheckRun(ctx context.Context, owner, repo string, opt github.CreateCheckRunOptions) (*github.CheckRun, error)
 }
 
 type checkerGitHubClient struct {
 	*github.Client
-}
-
-func (c *checkerGitHubClient) GetPullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error) {
-	pr, _, err := c.PullRequests.Get(ctx, owner, repo, number)
-	return pr, err
 }
 
 func (c *checkerGitHubClient) GetPullRequestDiff(ctx context.Context, owner, repo string, number int) ([]byte, error) {

--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -16,8 +16,10 @@ type CheckRequest struct {
 	// Repository name.
 	// Required.
 	Repo string `json:"repo,omitempty"`
+
 	// Branch name.
 	// Optional.
+	// DEPRECATED: No need to fill this field.
 	Branch string `json:"branch,omitempty"`
 
 	// Annotations associated with the repository's commit and Pull Request.


### PR DESCRIPTION
It seems it's not required anymore and it's not referred from the
document. https://developer.github.com/v3/checks/runs/#create-a-check-run