### PR TITLE
Fix type of IDs (int -> int64)

### DIFF
--- a/doghouse/server/github.go
+++ b/doghouse/server/github.go
@@ -39,13 +39,13 @@ func NewGitHubClient(ctx context.Context, opt *NewGitHubClientOption) (*github.C
 
 func githubAppTransport(ctx context.Context, client *http.Client, opt *NewGitHubClientOption) (http.RoundTripper, error) {
 	if opt.RepoOwner == "" {
-		return ghinstallation.NewAppsTransport(getTransport(client), opt.IntegrationID, opt.PrivateKey)
+		return ghinstallation.NewAppsTransport(getTransport(client), int64(opt.IntegrationID), opt.PrivateKey)
 	}
 	installationID, err := findInstallationID(ctx, opt)
 	if err != nil {
 		return nil, err
 	}
-	return ghinstallation.New(getTransport(client), opt.IntegrationID, int(installationID), opt.PrivateKey)
+	return ghinstallation.New(getTransport(client), int64(opt.IntegrationID), int64(installationID), opt.PrivateKey)
 }
 
 func getTransport(client *http.Client) http.RoundTripper {


### PR DESCRIPTION
Hi,

I've just faced following type errors on install.

```
...
# github.com/reviewdog/reviewdog/doghouse/server
../../reviewdog/reviewdog/doghouse/server/github.go:42:67: cannot use opt.IntegrationID (type int) as type int64 in argument to ghinstallation.NewAppsTransport
../../reviewdog/reviewdog/doghouse/server/github.go:48:53: cannot use opt.IntegrationID (type int) as type int64 in argument to ghinstallation.New
../../reviewdog/reviewdog/doghouse/server/github.go:48:72: cannot use int(installationID) (type int) as type int64 in argument to ghinstallation.New
```

Apparently, it seems that the type of IDs (`integrationID` and `installationID`) have both been updated by
a following PR on [bradleyfalzon/ghinstallation](https://github.com/bradleyfalzon/ghinstallation) as a breaking change.
https://github.com/bradleyfalzon/ghinstallation/pull/30

Then I've made a small PR fixing that. I hope that it works.

