### PR TITLE
fixes #359

### DIFF
--- a/doghouse/server/github.go
+++ b/doghouse/server/github.go
@@ -39,13 +39,13 @@ func NewGitHubClient(ctx context.Context, opt *NewGitHubClientOption) (*github.C
 
 func githubAppTransport(ctx context.Context, client *http.Client, opt *NewGitHubClientOption) (http.RoundTripper, error) {
 	if opt.RepoOwner == "" {
-		return ghinstallation.NewAppsTransport(getTransport(client), opt.IntegrationID, opt.PrivateKey)
+		return ghinstallation.NewAppsTransport(getTransport(client), int64(opt.IntegrationID), opt.PrivateKey)
 	}
 	installationID, err := findInstallationID(ctx, opt)
 	if err != nil {
 		return nil, err
 	}
-	return ghinstallation.New(getTransport(client), opt.IntegrationID, int(installationID), opt.PrivateKey)
+	return ghinstallation.New(getTransport(client), int64(opt.IntegrationID), installationID, opt.PrivateKey)
 }
 
 func getTransport(client *http.Client) http.RoundTripper {

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,7 @@ require (
 	cloud.google.com/go v0.46.3
 	cloud.google.com/go/datastore v1.0.0
 	cloud.google.com/go/storage v1.0.0 // indirect
-	github.com/bradleyfalzon/ghinstallation v0.1.2
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/bradleyfalzon/ghinstallation v1.0.0
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-github/v28 v28.1.1
 	github.com/haya14busa/secretbox v0.0.0-20180525171038-07c7ecf409f5

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/bradleyfalzon/ghinstallation v0.1.2 h1:9fdqVadlvEX/EUts5/aIGvx2ujKnGNIMcuCuUrM6s6Q=
-github.com/bradleyfalzon/ghinstallation v0.1.2/go.mod h1:VQsLlCoNa54/CNXcc2DuCfNZrZxqQcyPeqKUugF/2h8=
+github.com/bradleyfalzon/ghinstallation v1.0.0 h1:8F5diEz1VN4EcEFuinqhLYMQ95jD8rzhxjJHIGqIWM8=
+github.com/bradleyfalzon/ghinstallation v1.0.0/go.mod h1:p7iD8KytOOKg2wCqbwvJlq4JGpYMjwjkiqdyUqOIHLI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
It appears that the old version of ghinstallation was breaking the go get installation. Updated the version to the latest one and fixed the compilation errors.

See https://github.com/bradleyfalzon/ghinstallation/releases/tag/v1.0.0