### PR TITLE
Filter check results by all lines from diff by default

### DIFF
--- a/cmd/reviewdog/doghouse.go
+++ b/cmd/reviewdog/doghouse.go
@@ -39,7 +39,7 @@ func runDoghouse(ctx context.Context, r io.Reader, w io.Writer, opt *option, isP
 	if err != nil {
 		return err
 	}
-	filteredResultSet, err := postResultSet(ctx, resultSet, ghInfo, cli, forPr)
+	filteredResultSet, err := postResultSet(ctx, resultSet, ghInfo, cli, forPr, opt.filterMode)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func checkResultSet(ctx context.Context, r io.Reader, opt *option, isProject boo
 }
 
 func postResultSet(ctx context.Context, resultSet *reviewdog.ResultMap,
-	ghInfo *cienv.BuildInfo, cli client.DogHouseClientInterface, forPr bool) (*reviewdog.FilteredResultMap, error) {
+	ghInfo *cienv.BuildInfo, cli client.DogHouseClientInterface, forPr bool, filterMode reviewdog.FilterMode) (*reviewdog.FilteredResultMap, error) {
 	var g errgroup.Group
 	wd, _ := os.Getwd()
 	filteredResultSet := new(reviewdog.FilteredResultMap)
@@ -130,6 +130,7 @@ func postResultSet(ctx context.Context, resultSet *reviewdog.ResultMap,
 			Level:       result.Level,
 			// If it's only for PR, do not report results outside diff.
 			OutsideDiff: !forPr,
+			FilterMode:  filterMode,
 		}
 		g.Go(func() error {
 			res, err := cli.Check(ctx, req)

--- a/cmd/reviewdog/doghouse_test.go
+++ b/cmd/reviewdog/doghouse_test.go
@@ -273,7 +273,7 @@ func TestPostResultSet_withReportURL(t *testing.T) {
 		SHA:         sha,
 	}
 
-	if _, err := postResultSet(context.Background(), &resultSet, ghInfo, fakeCli, true); err != nil {
+	if _, err := postResultSet(context.Background(), &resultSet, ghInfo, fakeCli, true, reviewdog.FilterModeAdded); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -297,7 +297,7 @@ func TestPostResultSet_withoutReportURL(t *testing.T) {
 
 	ghInfo := &cienv.BuildInfo{Owner: owner, Repo: repo, PullRequest: prNum, SHA: sha}
 
-	resp, err := postResultSet(context.Background(), &resultSet, ghInfo, fakeCli, true)
+	resp, err := postResultSet(context.Background(), &resultSet, ghInfo, fakeCli, true, reviewdog.FilterModeAdded)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestPostResultSet_withEmptyResponse(t *testing.T) {
 
 	ghInfo := &cienv.BuildInfo{Owner: owner, Repo: repo, PullRequest: prNum, SHA: sha}
 
-	if _, err := postResultSet(context.Background(), &resultSet, ghInfo, fakeCli, true); err == nil {
+	if _, err := postResultSet(context.Background(), &resultSet, ghInfo, fakeCli, true, reviewdog.FilterModeAdded); err == nil {
 		t.Error("got no error but want report missing error")
 	}
 }

--- a/doghouse/server/doghouse.go
+++ b/doghouse/server/doghouse.go
@@ -49,7 +49,7 @@ func (ch *Checker) Check(ctx context.Context) (*doghouse.CheckResponse, error) {
 	}
 
 	results := annotationsToCheckResults(ch.req.Annotations)
-	filtered := reviewdog.FilterCheck(results, filediffs, 1, "")
+	filtered := reviewdog.FilterCheck(results, filediffs, 1, "", false)
 
 	check, err := ch.createCheck(ctx)
 	if err != nil {

--- a/doghouse/server/doghouse.go
+++ b/doghouse/server/doghouse.go
@@ -49,8 +49,7 @@ func (ch *Checker) Check(ctx context.Context) (*doghouse.CheckResponse, error) {
 	}
 
 	results := annotationsToCheckResults(ch.req.Annotations)
-	filtered := reviewdog.FilterCheck(results, filediffs, 1, "", false)
-
+	filtered := reviewdog.FilterCheck(results, filediffs, 1, "", ch.req.FilterMode)
 	check, err := ch.createCheck(ctx)
 	if err != nil {
 		// If this error is StatusForbidden (403) here, it means reviewdog is

--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -40,6 +40,10 @@ type CheckRequest struct {
 	// (because there are no diff!).
 	// Optional.
 	OutsideDiff bool `json:"outside_diff"`
+
+	// FilterMode represents a way to filter checks results
+	// Optional.
+	FilterMode reviewdog.FilterMode `json:"filter_mode"`
 }
 
 // CheckResponse represents doghouse GitHub check response.

--- a/filter.go
+++ b/filter.go
@@ -33,10 +33,10 @@ func (mode *FilterMode) String() string {
 // Set implements the flag.Value interface
 func (mode *FilterMode) Set(value string) error {
 	switch value {
-	case "added":
-		*mode = FilterModeAdded
 	case "diff_context":
 		*mode = FilterModeDiffContext
+	case "added":
+		*mode = FilterModeAdded
 	default:
 		*mode = FilterModeDiffContext
 	}
@@ -58,10 +58,10 @@ func FilterCheck(results []*CheckResult, diff []*diff.FileDiff, strip int, wd st
 	var filterFn lineComparator
 
 	switch filterMode {
-	case FilterModeAdded:
-		filterFn = isAddedLine
 	case FilterModeDiffContext:
 		filterFn = anyLine
+	case FilterModeAdded:
+		filterFn = isAddedLine
 	}
 
 	significantlines := significantDiffLines(diff, filterFn, strip)

--- a/project/run.go
+++ b/project/run.go
@@ -78,7 +78,7 @@ func RunAndParse(ctx context.Context, conf *Config, runners map[string]bool, def
 }
 
 // Run runs reviewdog tasks based on Config.
-func Run(ctx context.Context, conf *Config, runners map[string]bool, c reviewdog.CommentService, d reviewdog.DiffService, teeMode bool) error {
+func Run(ctx context.Context, conf *Config, runners map[string]bool, c reviewdog.CommentService, d reviewdog.DiffService, teeMode bool, filterMode reviewdog.FilterMode) error {
 	results, err := RunAndParse(ctx, conf, runners, "", teeMode) // Level is not used.
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func Run(ctx context.Context, conf *Config, runners map[string]bool, c reviewdog
 	results.Range(func(toolname string, result *reviewdog.Result) {
 		rs := result.CheckResults
 		g.Go(func() error {
-			return reviewdog.RunFromResult(ctx, c, rs, filediffs, d.Strip(), toolname)
+			return reviewdog.RunFromResult(ctx, c, rs, filediffs, d.Strip(), toolname, filterMode)
 		})
 	})
 	return g.Wait()

--- a/project/run_test.go
+++ b/project/run_test.go
@@ -38,7 +38,7 @@ func TestRun(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		conf := &Config{}
-		if err := Run(ctx, conf, nil, nil, nil, false); err != nil {
+		if err := Run(ctx, conf, nil, nil, nil, false, reviewdog.FilterModeAdded); err != nil {
 			t.Error(err)
 		}
 	})
@@ -49,7 +49,7 @@ func TestRun(t *testing.T) {
 				"test": {},
 			},
 		}
-		if err := Run(ctx, conf, nil, nil, nil, false); err == nil {
+		if err := Run(ctx, conf, nil, nil, nil, false, reviewdog.FilterModeAdded); err == nil {
 			t.Error("want error, got nil")
 		} else {
 			t.Log(err)
@@ -70,7 +70,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, nil, nil, ds, false); err == nil {
+		if err := Run(ctx, conf, nil, nil, ds, false, reviewdog.FilterModeAdded); err == nil {
 			t.Error("want error, got nil")
 		} else {
 			t.Log(err)
@@ -98,7 +98,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, nil, cs, ds, false); err != nil {
+		if err := Run(ctx, conf, nil, cs, ds, false, reviewdog.FilterModeAdded); err != nil {
 			t.Error(err)
 		}
 		want := ""
@@ -128,7 +128,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, nil, cs, ds, true); err != nil {
+		if err := Run(ctx, conf, nil, cs, ds, true, reviewdog.FilterModeAdded); err != nil {
 			t.Error(err)
 		}
 		want := "sh: 1: not: not found\n"
@@ -156,7 +156,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, nil, cs, ds, false); err != nil {
+		if err := Run(ctx, conf, nil, cs, ds, false, reviewdog.FilterModeAdded); err != nil {
 			t.Error(err)
 		}
 	})
@@ -182,7 +182,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, nil, cs, ds, true); err != nil {
+		if err := Run(ctx, conf, nil, cs, ds, true, reviewdog.FilterModeAdded); err != nil {
 			t.Error(err)
 		}
 		want := "hi\n"
@@ -218,7 +218,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, map[string]bool{"test2": true}, cs, ds, false); err != nil {
+		if err := Run(ctx, conf, map[string]bool{"test2": true}, cs, ds, false, reviewdog.FilterModeAdded); err != nil {
 			t.Error(err)
 		}
 		if called != 1 {
@@ -251,7 +251,7 @@ func TestRun(t *testing.T) {
 				},
 			},
 		}
-		if err := Run(ctx, conf, map[string]bool{"hoge": true}, cs, ds, false); err == nil {
+		if err := Run(ctx, conf, map[string]bool{"hoge": true}, cs, ds, false, reviewdog.FilterModeAdded); err == nil {
 			t.Error("got no error but want runner not found error")
 		}
 	})

--- a/reviewdog.go
+++ b/reviewdog.go
@@ -79,7 +79,7 @@ func (w *Reviewdog) runFromResult(ctx context.Context, results []*CheckResult,
 		return err
 	}
 
-	checks := FilterCheck(results, filediffs, strip, wd)
+	checks := FilterCheck(results, filediffs, strip, wd, true)
 	for _, check := range checks {
 		if !check.InDiff {
 			continue

--- a/reviewdog.go
+++ b/reviewdog.go
@@ -14,20 +14,22 @@ import (
 // or linter, get diff and filter the results by diff, and report filtered
 // results.
 type Reviewdog struct {
-	toolname string
-	p        Parser
-	c        CommentService
-	d        DiffService
+	toolname   string
+	p          Parser
+	c          CommentService
+	d          DiffService
+	filterMode FilterMode
 }
 
 // NewReviewdog returns a new Reviewdog.
-func NewReviewdog(toolname string, p Parser, c CommentService, d DiffService) *Reviewdog {
-	return &Reviewdog{p: p, c: c, d: d, toolname: toolname}
+func NewReviewdog(toolname string, p Parser, c CommentService, d DiffService, filterMode FilterMode) *Reviewdog {
+	return &Reviewdog{p: p, c: c, d: d, toolname: toolname, filterMode: filterMode}
 }
 
+// RunFromResult creates a new Reviewdog and runs it with check results.
 func RunFromResult(ctx context.Context, c CommentService, results []*CheckResult,
-	filediffs []*diff.FileDiff, strip int, toolname string) error {
-	return (&Reviewdog{c: c, toolname: toolname}).runFromResult(ctx, results, filediffs, strip)
+	filediffs []*diff.FileDiff, strip int, toolname string, filterMode FilterMode) error {
+	return (&Reviewdog{c: c, toolname: toolname, filterMode: filterMode}).runFromResult(ctx, results, filediffs, strip)
 }
 
 // CheckResult represents a checked result of static analysis tools.
@@ -79,7 +81,8 @@ func (w *Reviewdog) runFromResult(ctx context.Context, results []*CheckResult,
 		return err
 	}
 
-	checks := FilterCheck(results, filediffs, strip, wd, true)
+	checks := FilterCheck(results, filediffs, strip, wd, w.filterMode)
+
 	for _, check := range checks {
 		if !check.InDiff {
 			continue

--- a/reviewdog_test.go
+++ b/reviewdog_test.go
@@ -47,7 +47,7 @@ golint.new.go:11:1: comment on exported function F2 should be of the form "F2 ..
 	p := NewErrorformatParser(efm)
 	c := NewRawCommentWriter(os.Stdout)
 	d := NewDiffString(difftext, 1)
-	app := NewReviewdog("tool name", p, c, d)
+	app := NewReviewdog("tool name", p, c, d, FilterModeAdded)
 	app.Run(context.Background(), strings.NewReader(lintresult))
 	// Unordered output:
 	// golint.new.go:5:5: exported var NewError1 should have comment or be unexported
@@ -93,6 +93,6 @@ index 34cacb9..a727dd3 100644
 	efm, _ := errorformat.NewErrorformat([]string{`%f:%l:%c: %m`})
 	p := NewErrorformatParser(efm)
 	d := NewDiffString(difftext, 1)
-	app := NewReviewdog("tool name", p, c, d)
+	app := NewReviewdog("tool name", p, c, d, FilterModeAdded)
 	app.Run(context.Background(), strings.NewReader(lintresult))
 }


### PR DESCRIPTION
Current behaviour:
When reviewdog filters the check results by diff, which is either provided by cli option or taken from Gitbub or Gitlab PR/MR, it does so only taking into account the lines marked as added in the diff. This has certain downsides described in #187.

New behaviour:
Filter check results by all the lines from diff but add the option to force the existing logic of filtering only by added diff lines.