### PR TITLE
go tool vet and shadow option are not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ runner:
       - "%f:%l:%c: %m"
     level: warning
   govet:
-    cmd: go tool vet -all -shadowstrict .
+    cmd: go vet -all .
 ```
 
 ```shell


### PR DESCRIPTION
go tool vet itself and `-shadowstrict` option are not supported in newer Go

reference: https://golang.org/doc/go1.12#vet