### PR TITLE
fix: GitLab CI MergeTrains

### DIFF
--- a/cienv/cienv.go
+++ b/cienv/cienv.go
@@ -104,6 +104,8 @@ func getPullRequestNum() int {
 		"CIRCLE_PR_NUMBER",    // For Pull Request by a fork repository
 		// drone.io.
 		"DRONE_PULL_REQUEST",
+		// GitLab CI MergeTrains
+		"CI_MERGE_REQUEST_IID"
 	}
 	// regexp.MustCompile() in func intentionally because this func is called
 	// once for one run.

--- a/cienv/cienv.go
+++ b/cienv/cienv.go
@@ -105,7 +105,7 @@ func getPullRequestNum() int {
 		// drone.io.
 		"DRONE_PULL_REQUEST",
 		// GitLab CI MergeTrains
-		"CI_MERGE_REQUEST_IID"
+		"CI_MERGE_REQUEST_IID",
 	}
 	// regexp.MustCompile() in func intentionally because this func is called
 	// once for one run.


### PR DESCRIPTION
## Problem

GitLab has a Feature called Merge Trains(see https://docs.gitlab.com/ee/ci/merge_request_pipelines/pipelines_for_merged_results/merge_trains/), which creates a "speculative" merge commit of the branch with the merge target and runs CI on that commit.

This commit is not part of the Merge Request, therefore the logic to find the MR for the SHA that works without Merge Trains does not work any more.

## Solution

Thankfully the env var "CI_MERGE_REQUEST_IID" is provided to get the MR for the pipeline (see https://docs.gitlab.com/ee/ci/variables/predefined_variables.html).