### PR TITLE
Allow forced skipping of the doghouse server.

### DIFF
--- a/cmd/reviewdog/doghouse.go
+++ b/cmd/reviewdog/doghouse.go
@@ -52,7 +52,8 @@ func runDoghouse(ctx context.Context, r io.Reader, w io.Writer, opt *option, isP
 func newDoghouseCli(ctx context.Context) (client.DogHouseClientInterface, error) {
 	// If skipDoghouseServer is true, run doghouse code directly instead of talking to
 	// the doghouse server because provided GitHub API Token has Check API scope.
-	skipDoghouseServer := cienv.IsInGitHubAction() && os.Getenv("REVIEWDOG_TOKEN") == ""
+	// You can force skipping the doghouse server if you are generating your own application API token.
+	skipDoghouseServer := (os.Getenv("REVIEWDOG_SKIP_DOGHOUSE") == "true" || cienv.IsInGitHubAction()) && os.Getenv("REVIEWDOG_TOKEN") == ""
 	if skipDoghouseServer {
 		token, err := nonEmptyEnv("REVIEWDOG_GITHUB_API_TOKEN")
 		if err != nil {


### PR DESCRIPTION
If you create your own app integration and use that to create your GitHub API key, you can use that key to push to the checks API without being in GitHub actions. This works fine, there's just no way to skip the doghouse server without also failing other github action conditionals.