### PR TITLE
gitlab: support -filter-mode=[file/diff_context]

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          golint | reviewdog -f=golint -name=golint-pr-check-filter-mode-file -reporter=github-pr-check -filter-mode=file
+          golint | reviewdog -f=golint -name=golint-pr-check-filter-mode-file -reporter=github-pr-check -filter-mode=file -level=warning
 
   golangci-lint:
     if: github.event_name == 'pull_request'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+# Go to https://gitlab.com/reviewdog/reviewdog/-/settings/repository#js-push-remote-settings
+# to sync the repository manually.
+
 # Open merge request automatically and run reviewdog against created MR.
 stages:
   - openMr
@@ -37,6 +40,6 @@ Reviewdog:
     - go install ./cmd/reviewdog
     - ( cd linters && go get golang.org/x/lint/golint )
   script:
-    - golint ./... | reviewdog -f=golint -name=golint-discussion -reporter=gitlab-mr-discussion
+    - golint ./... | reviewdog -f=golint -name=golint-discussion -reporter=gitlab-mr-discussion -filter-mode=file
     - golint ./... | reviewdog -f=golint -name=golint-commit -reporter=gitlab-mr-commit
-    - cd ./_testdata/ && golint ./... | reviewdog -f=golint -name=golint-discussion -reporter=gitlab-mr-discussion
+    - cd ./_testdata/ && golint ./... | reviewdog -f=golint -name=golint-discussion-subdir -reporter=gitlab-mr-discussion

--- a/difffilter/filter_test.go
+++ b/difffilter/filter_test.go
@@ -129,7 +129,11 @@ func TestDiffFilter_root(t *testing.T) {
 	}
 	for _, tt := range tests {
 		df := New(files, 1, getCwd(), tt.mode)
-		if got, gotLnumDiff := df.InDiff(tt.path, tt.lnum); got != tt.want {
+		if got, gotLine := df.InDiff(tt.path, tt.lnum); got != tt.want {
+			gotLnumDiff := 0
+			if gotLine != nil {
+				gotLnumDiff = gotLine.LnumDiff
+			}
 			t.Errorf("InDiff(%q, %d) = (%v, %d), want (%v, %d)",
 				tt.path, tt.lnum, got, gotLnumDiff, tt.want, tt.wantLnumDiff)
 		}
@@ -172,7 +176,11 @@ func TestDiffFilter_subdir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		df := New(files, 1, getCwd(), tt.mode)
-		if got, gotLnumDiff := df.InDiff(tt.path, tt.lnum); got != tt.want {
+		if got, gotLine := df.InDiff(tt.path, tt.lnum); got != tt.want {
+			gotLnumDiff := 0
+			if gotLine != nil {
+				gotLnumDiff = gotLine.LnumDiff
+			}
 			t.Errorf("InDiff(%q, %d) = (%v, %d), want (%v, %d)",
 				tt.path, tt.lnum, got, gotLnumDiff, tt.want, tt.wantLnumDiff)
 		}

--- a/filter_test.go
+++ b/filter_test.go
@@ -31,6 +31,17 @@ const diffContent = `--- sample.old.txt	2016-10-13 05:09:35.820791185 +0900
 \ No newline at end of file
 `
 
+const diffContentAddedStrip = `diff --git a/test_added.go b/test_added.go
+new file mode 100644
+index 0000000..264c67e
+--- /dev/null
++++ b/test_added.go
+@@ -0,0 +1,3 @@
++package reviewdog
++
++var TestAdded = 14
+`
+
 func TestFilterCheckByAddedLines(t *testing.T) {
 	results := []*CheckResult{
 		{
@@ -56,7 +67,9 @@ func TestFilterCheckByAddedLines(t *testing.T) {
 				Path: "sample.new.txt",
 				Lnum: 1,
 			},
-			InDiff: false,
+			InDiff:  false,
+			OldPath: "sample.old.txt",
+			OldLine: 1,
 		},
 		{
 			CheckResult: &CheckResult{
@@ -65,13 +78,17 @@ func TestFilterCheckByAddedLines(t *testing.T) {
 			},
 			InDiff:   true,
 			LnumDiff: 3,
+			OldPath:  "sample.old.txt",
+			OldLine:  0,
 		},
 		{
 			CheckResult: &CheckResult{
 				Path: "nonewline.new.txt",
 				Lnum: 1,
 			},
-			InDiff: false,
+			InDiff:  false,
+			OldPath: "nonewline.old.txt",
+			OldLine: 1,
 		},
 		{
 			CheckResult: &CheckResult{
@@ -80,6 +97,8 @@ func TestFilterCheckByAddedLines(t *testing.T) {
 			},
 			InDiff:   true,
 			LnumDiff: 5,
+			OldPath:  "nonewline.old.txt",
+			OldLine:  0,
 		},
 	}
 	filediffs, _ := diff.ParseMultiFile(strings.NewReader(diffContent))
@@ -113,6 +132,8 @@ func TestFilterCheckByDiffContext(t *testing.T) {
 			},
 			InDiff:   true,
 			LnumDiff: 1,
+			OldPath:  "sample.old.txt",
+			OldLine:  1,
 		},
 		{
 			CheckResult: &CheckResult{
@@ -121,6 +142,8 @@ func TestFilterCheckByDiffContext(t *testing.T) {
 			},
 			InDiff:   true,
 			LnumDiff: 3,
+			OldPath:  "sample.old.txt",
+			OldLine:  0,
 		},
 		{
 			CheckResult: &CheckResult{
@@ -129,11 +152,71 @@ func TestFilterCheckByDiffContext(t *testing.T) {
 			},
 			InDiff:   true,
 			LnumDiff: 4,
+			OldPath:  "sample.old.txt",
+			OldLine:  0,
 		},
 	}
 	filediffs, _ := diff.ParseMultiFile(strings.NewReader(diffContent))
 	got := FilterCheck(results, filediffs, 0, "", difffilter.ModeDiffContext)
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Error(diff)
+	}
+}
+
+func TestGetOldPosition(t *testing.T) {
+	const strip = 0
+	filediffs, _ := diff.ParseMultiFile(strings.NewReader(diffContent))
+	tests := []struct {
+		newPath     string
+		newLine     int
+		wantOldPath string
+		wantOldLine int
+	}{
+		{
+			newPath:     "sample.new.txt",
+			newLine:     1,
+			wantOldPath: "sample.old.txt",
+			wantOldLine: 1,
+		},
+		{
+			newPath:     "sample.new.txt",
+			newLine:     2,
+			wantOldPath: "sample.old.txt",
+			wantOldLine: 0,
+		},
+		{
+			newPath:     "sample.new.txt",
+			newLine:     3,
+			wantOldPath: "sample.old.txt",
+			wantOldLine: 0,
+		},
+		{
+			newPath:     "sample.new.txt",
+			newLine:     14,
+			wantOldPath: "sample.old.txt",
+			wantOldLine: 13,
+		},
+		{
+			newPath:     "not_found",
+			newLine:     14,
+			wantOldPath: "",
+			wantOldLine: 0,
+		},
+	}
+	for _, tt := range tests {
+		gotPath, gotLine := getOldPosition(filediffs, strip, tt.newPath, tt.newLine)
+		if !(gotPath == tt.wantOldPath && gotLine == tt.wantOldLine) {
+			t.Errorf("getOldPosition(..., %s, %d) = (%s, %d), want (%s, %d)",
+				tt.newPath, tt.newLine, gotPath, gotLine, tt.wantOldPath, tt.wantOldLine)
+		}
+	}
+}
+
+func TestGetOldPosition_added(t *testing.T) {
+	const strip = 1
+	filediffs, _ := diff.ParseMultiFile(strings.NewReader(diffContentAddedStrip))
+	gotPath, _ := getOldPosition(filediffs, strip, "test_added.go", 1)
+	if gotPath != "" {
+		t.Errorf("got %q as old path for addedd diff file, want empty", gotPath)
 	}
 }

--- a/reviewdog.go
+++ b/reviewdog.go
@@ -53,9 +53,12 @@ type Parser interface {
 // Comment represents a reported result as a comment.
 type Comment struct {
 	*CheckResult
+	ToolName string
 	Body     string
 	LnumDiff int
-	ToolName string
+	DiffLine *diff.Line
+	OldPath  string
+	OldLine  int
 }
 
 // CommentService is an interface which posts Comment.
@@ -92,8 +95,10 @@ func (w *Reviewdog) runFromResult(ctx context.Context, results []*CheckResult,
 		}
 		comment := &Comment{
 			CheckResult: check.CheckResult,
-			Body:        check.Message, // TODO: format message
+			Body:        check.Message,
 			LnumDiff:    check.LnumDiff,
+			OldPath:     check.OldPath,
+			OldLine:     check.OldLine,
 			ToolName:    w.toolname,
 		}
 		if err := w.c.Post(ctx, comment); err != nil {

--- a/service/commentutil/commentutil.go
+++ b/service/commentutil/commentutil.go
@@ -2,6 +2,7 @@ package commentutil
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/reviewdog/reviewdog"
 )
@@ -37,6 +38,15 @@ func (p PostedComments) AddPostedComment(path string, lineNum int, body string) 
 		p[path][lineNum] = make([]string, 0)
 	}
 	p[path][lineNum] = append(p[path][lineNum], body)
+}
+
+// DebugLog outputs posted comments as log for debugging.
+func (p PostedComments) DebugLog() {
+	for filename, f := range p {
+		for line := range f {
+			log.Printf("[debug] posted: %s:%d", filename, line)
+		}
+	}
 }
 
 // BodyPrefix is prefix text of comment body.

--- a/service/gitlab/gitlab_mr_discussion_test.go
+++ b/service/gitlab/gitlab_mr_discussion_test.go
@@ -48,12 +48,22 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 		},
 		Body: "new comment 2",
 	}
+	newComment3 := &reviewdog.Comment{
+		CheckResult: &reviewdog.CheckResult{
+			Path: "new_file.go",
+			Lnum: 14,
+		},
+		Body:    "new comment 3",
+		OldPath: "old_file.go",
+		OldLine: 7,
+	}
 
 	comments := []*reviewdog.Comment{
 		alreadyCommented1,
 		alreadyCommented2,
 		newComment1,
 		newComment2,
+		newComment3,
 	}
 
 	mux := http.NewServeMux()
@@ -125,6 +135,18 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 					Body: gitlab.String(commentutil.CommentBody(newComment2)),
 					Position: &gitlab.NotePosition{
 						BaseSHA: "xxx", StartSHA: "xxx", HeadSHA: "sha", PositionType: "text", NewPath: "file2.go", NewLine: 15},
+				}
+				if diff := cmp.Diff(got, want); diff != "" {
+					t.Error(diff)
+				}
+			case "new_file.go":
+				want := &gitlab.CreateMergeRequestDiscussionOptions{
+					Body: gitlab.String(commentutil.CommentBody(newComment3)),
+					Position: &gitlab.NotePosition{
+						BaseSHA: "xxx", StartSHA: "xxx", HeadSHA: "sha", PositionType: "text",
+						NewPath: "new_file.go", NewLine: 14,
+						OldPath: "old_file.go", OldLine: 7,
+					},
 				}
 				if diff := cmp.Diff(got, want); diff != "" {
 					t.Error(diff)


### PR DESCRIPTION
GitLab returns an error if old path/line is not specified where
 appropriate.