### PR TITLE
cmd: use CI_API_V4_URL env as gitlab API URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :book: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
+- [#563](https://github.com/reviewdog/reviewdog/issues/563) Use `CI_API_V4_URL` environment variable when present. 
 - ...
 
 ### :bug: Fixes

--- a/README.md
+++ b/README.md
@@ -384,7 +384,9 @@ $ export REVIEWDOG_GITLAB_API_TOKEN="<token>"
 $ reviewdog -reporter=gitlab-mr-discussion
 ```
 
-For self-hosted GitLab, set API endpoint by environment variable.
+The `CI_API_V4_URL` environment variable, defined automatically by Gitlab CI (v11.7 onwards), will be used to find out the Gitlab API URL.
+
+Alternatively, `GITLAB_API` can also be defined, in which case it will take precedence over `CI_API_V4_URL`.
 
 ```shell
 $ export GITLAB_API="https://example.gitlab.com/api/v4"

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -130,7 +130,8 @@ const (
 		1. Set REVIEWDOG_GITLAB_API_TOKEN environment variable.
 		Go to https://gitlab.com/profile/personal_access_tokens
 
-		For self hosted GitLab:
+		CI_API_V4_URL (defined by Gitlab CI) as the base URL for the Gitlab API automatically.
+		Alternatively, GITLAB_API can also be defined, and it will take precedence over the former:
 			$ export GITLAB_API="https://example.gitlab.com/api/v4"
 
 	"gitlab-mr-commit"
@@ -596,10 +597,19 @@ func gitlabClient(token string) (*gitlab.Client, error) {
 const defaultGitLabAPI = "https://gitlab.com/api/v4"
 
 func gitlabBaseURL() (*url.URL, error) {
-	baseURL := os.Getenv("GITLAB_API")
-	if baseURL == "" {
+	gitlabApi := os.Getenv("GITLAB_API")
+	gitlabV4Url := os.Getenv("CI_API_V4_URL")
+
+	var baseURL string
+	switch true {
+	case gitlabApi != "":
+		baseURL = gitlabApi
+	case gitlabV4Url != "":
+		baseURL = gitlabV4Url
+	default:
 		baseURL = defaultGitLabAPI
 	}
+
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("GitLab base URL is invalid: %v, %v", baseURL, err)

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -597,16 +597,15 @@ func gitlabClient(token string) (*gitlab.Client, error) {
 const defaultGitLabAPI = "https://gitlab.com/api/v4"
 
 func gitlabBaseURL() (*url.URL, error) {
-	gitlabApi := os.Getenv("GITLAB_API")
-	gitlabV4Url := os.Getenv("CI_API_V4_URL")
+	gitlabAPI := os.Getenv("GITLAB_API")
+	gitlabV4URL := os.Getenv("CI_API_V4_URL")
 
 	var baseURL string
-	switch true {
-	case gitlabApi != "":
-		baseURL = gitlabApi
-	case gitlabV4Url != "":
-		baseURL = gitlabV4Url
-	default:
+	if gitlabAPI != "" {
+		baseURL = gitlabAPI
+	} else if gitlabV4URL != "" {
+		baseURL = gitlabV4URL
+	} else {
 		baseURL = defaultGitLabAPI
 	}
 


### PR DESCRIPTION
This should be a simple change, although it has not been extensively tested.

Closes #563.