### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ $ reviewdog -reporter=github-pr-review -filter-mode=nofilter -fail-on-error
 ```
 
 ### Filter Mode Support Table
-Note that not all reporters provide full suppport of filter mode due to API limitation.
+Note that not all reporters provide full support of filter mode due to API limitation.
 e.g. `github-pr-review` reporter uses [GitHub Review
 API](https://developer.github.com/v3/pulls/reviews/) but it doesn't support posting comment outside diff (`diff_context`),
 so reviewdog will use [Check annotation](https://developer.github.com/v3/checks/runs/) as fallback to post those comments [1]. 

--- a/doghouse/appengine/app.yaml
+++ b/doghouse/appengine/app.yaml
@@ -17,7 +17,7 @@ includes:
 # GitHub APIs, so it should be safe to increase the scaling condition while
 # preserving the performance.
 #
-# reviewdog CLI tipically call multiple requests at the same time, so the
+# reviewdog CLI typically call multiple requests at the same time, so the
 # default max_concurrent_requests (=10) seems to be too small and it can be a
 # reason why AppEngine starts multiple instances for the reviewdog server.
 #

--- a/doghouse/appengine/github.go
+++ b/doghouse/appengine/github.go
@@ -253,7 +253,7 @@ func notfound(w http.ResponseWriter) {
 func (g *GitHubHandler) getUserOrBadRequest(ctx context.Context, ghcli *github.Client, w http.ResponseWriter) (bool, *github.User) {
 	u, _, err := ghcli.Users.Get(ctx, "")
 	if err != nil {
-		// Token seeims invalid. Clear it before returning BadRequest status.
+		// Token seems invalid. Clear it before returning BadRequest status.
 		g.tokenStore.Clear(w)
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "Cannot get GitHub authenticated user. Please reload the page again.")

--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -37,7 +37,7 @@ type CheckRequest struct {
 	// Optional.
 	Level string `json:"level"`
 
-	// Deprecated: Use FilterMode == diffilter.NoFilter instead.
+	// Deprecated: Use FilterMode == difffilter.NoFilter instead.
 	//
 	// OutsideDiff represents whether it report results in outside diff or not as
 	// annotations. It's useful only when PullRequest != 0. If PullRequest is

--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -37,7 +37,7 @@ type CheckRequest struct {
 	// Optional.
 	Level string `json:"level"`
 
-	// Deprecatd: Use FilterMode == diffilter.NoFilter instead.
+	// Deprecated: Use FilterMode == diffilter.NoFilter instead.
 	//
 	// OutsideDiff represents whether it report results in outside diff or not as
 	// annotations. It's useful only when PullRequest != 0. If PullRequest is

--- a/filter_test.go
+++ b/filter_test.go
@@ -236,6 +236,6 @@ func TestGetOldPosition_added(t *testing.T) {
 	fdiff := findFileDiff(filediffs, path, strip)
 	gotPath, _ := getOldPosition(fdiff, strip, path, 1)
 	if gotPath != "" {
-		t.Errorf("got %q as old path for addedd diff file, want empty", gotPath)
+		t.Errorf("got %q as old path for added diff file, want empty", gotPath)
 	}
 }

--- a/project/cmdbuilder.go
+++ b/project/cmdbuilder.go
@@ -33,7 +33,7 @@ func (cb *cmdBuilder) build(ctx context.Context, command string) (*exec.Cmd, io.
 	shell := "sh"
 	args := []string{"-c", command}
 	if runtime.GOOS == "windows" {
-		// Under Windows the executalbe sh is not always available
+		// Under Windows the executable sh is not always available
 		// If running under MinGW the environment variable SHELL would be set
 		SHELL := os.Getenv("SHELL")
 		// Otherwise use the environment variable COMSPEC (path to cmd.exe)


### PR DESCRIPTION
Misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

It reported: https://github.com/jsoref/reviewdog/commit/de0ec0920bb49e49c5a9f78a17ce35fbab13da0b#commitcomment-39961125

And it validated that the changes in this PR made it happy: https://github.com/jsoref/reviewdog/commit/cf492f0ef8df1d5925f2c56652d2ee9e4f7cc47a

Note: this PR does not include the action, if you're interested, that can be offered separately.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

