### PR TITLE
github-check doesn't report results outside diff by default now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ $ cd subdir/ && reviewdog -filter-mode=file -fail-on-error -reporter=github-pr-r
 ### :bug: Fixes
 - [#461](https://github.com/reviewdog/reviewdog/issues/461) All reporters now supports sub-directory run. ([@haya14busa])
 
+### :rotating_light: Breaking changes
+- `github-check` reporter won't report results outside diff by default now. You
+  need to use `-filter-mode=nofilter` to keep the same bahavior.
+
 ---
 
 See https://github.com/reviewdog/reviewdog/releases for older release note.

--- a/README.md
+++ b/README.md
@@ -342,8 +342,7 @@ server.
 ### Reporter: GitHub Checks (-reporter=github-check)
 
 It's basically same as `-reporter=github-pr-check` except it works not only for
-Pull Request but also for commit and it reports results outside Pull Request
-diff too.
+Pull Request but also for commit.
 
 [![sample comment outside diff](https://user-images.githubusercontent.com/3797062/69917921-e0680580-14ae-11ea-9a56-de9e3cbac005.png)](https://github.com/reviewdog/reviewdog/pull/364/files)
 


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Users need to use --filter-mode=nofilter to report results outside diff

ref: #637