### PR TITLE
Fix detection logic to determin Pull Requests from forked repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :book: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- [#563](https://github.com/reviewdog/reviewdog/issues/563) Use `CI_API_V4_URL` environment variable when present. 
+- [#563](https://github.com/reviewdog/reviewdog/issues/563) Use `CI_API_V4_URL` environment variable when present.
 - ...
 
 ### :bug: Fixes
 - [#609](https://github.com/reviewdog/reviewdog/issues/609) reviewdog command will fail with unexpected tool's error for github-check/github-pr-check reporters as well. ([@haya14busa])
+- [#603](https://github.com/reviewdog/reviewdog/issues/603) Fixed detection of Pull Requests from forked repo. ([@haya14busa])
 - ...
 
 ### :rotating_light: Breaking changes

--- a/cmd/reviewdog/doghouse.go
+++ b/cmd/reviewdog/doghouse.go
@@ -193,11 +193,10 @@ func checkResultToAnnotation(c *reviewdog.CheckResult, wd, gitRelWd string) *dog
 // It returns true if reviewdog should exit with 1.
 // e.g. At least one annotation result is in diff.
 func reportResults(w io.Writer, filteredResultSet *reviewdog.FilteredResultMap) bool {
-	if filteredResultSet.Len() != 0 && isPRFromForkedRepo() {
+	if filteredResultSet.Len() != 0 && cienv.IsGitHubPRFromForkedRepo() {
 		fmt.Fprintln(w, `reviewdog: This is Pull-Request from forked repository.
 GitHub token doesn't have write permission of Check API, so reviewdog will
 report results via logging command [1].
-
 [1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands`)
 	}
 
@@ -251,12 +250,4 @@ report results via logging command [1].
 		}
 	}
 	return shouldFail
-}
-
-func isPRFromForkedRepo() bool {
-	event, err := cienv.LoadGitHubEvent()
-	if err != nil {
-		return false
-	}
-	return event.PullRequest.Head.Repo.Fork
 }

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -266,12 +266,11 @@ See -reporter flag for migration and set -reporter="github-pr-review" or -report
 		// instead of review comment because if it's PR from forked repository,
 		// GitHub token doesn't have write permission due to security concern and
 		// cannot post results via Review API.
-		if cienv.IsInGitHubAction() && isPRFromForkedRepo() {
+		if cienv.IsInGitHubAction() && cienv.IsGitHubPRFromForkedRepo() {
 			fmt.Fprintln(w, `reviewdog: This is Pull-Request from forked repository.
 GitHub token doesn't have write permission of Review API, so reviewdog will
 report results via logging command [1] and create annotations similar to
 github-pr-check reporter as a fallback.
-
 [1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands`)
 			cs = githubutils.NewGitHubActionLogWriter(opt.level)
 		} else {

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Head and base repos can be the same *forked* repo, so refering to head
repo's "fork" field was not enough.

Fix #603