### PR TITLE
Fix v0.10.1 release

### DIFF
--- a/.github/goreleaser-header.md
+++ b/.github/goreleaser-header.md
@@ -1,0 +1,1 @@
+See [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         if: "steps.tag.outputs.value != ''"
         with:
           version: latest
-          args: release --rm-dist --release-header <(echo -n 'See [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md)')
+          args: release --rm-dist --release-header .github/goreleaser-header.md
         env:
           # Need to use personal access token instead of default token to
           # update https://github.com/reviewdog/homebrew-tap.


### PR DESCRIPTION
It seems process substitution syntax did not work because 'args' for
actions won't be handled as bash arguments.

Error:

/opt/hostedtoolcache/goreleaser-action/0.138.0/x64/goreleaser release
--rm-dist --release-header <(echo -n 'See
[CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md)')

   ⨯ command failed            error=unknown shorthand flag: 'n' in -n

https://github.com/reviewdog/reviewdog/runs/819469712?check_suite_focus=true