### PR TITLE
Feature: Unified Reporter

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -89,6 +89,13 @@ const (
 	"local" (default)
 		Report results to stdout.
 
+	"unified"
+		Similar to local, but outputs in the "project" output format:
+			- <file>: [<tool name>] <message>
+			- <file>:<lnum>: [<tool name>] <message>
+			- <file>:<lnum>:<col>: [<tool name>] <message>
+		where <message> can be multiple lines.
+
 	"github-check"
 		Report results to GitHub Check. It works both for Pull Requests and commits.
 		For Pull Request, you can see report results in GitHub PullRequest Check
@@ -235,7 +242,7 @@ See -reporter flag for migration and set -reporter="github-pr-review" or -report
 	var cs reviewdog.CommentService
 	var ds reviewdog.DiffService
 
-	if isProject {
+	if isProject || opt.reporter == "unified" {
 		cs = reviewdog.NewUnifiedCommentWriter(w)
 	} else {
 		cs = reviewdog.NewRawCommentWriter(w)
@@ -333,7 +340,7 @@ github-pr-check reporter as a fallback.
 			return err
 		}
 		ds = d
-	case "local":
+	case "local", "unified":
 		if opt.diffCmd == "" && opt.filterMode == difffilter.ModeNoFilter {
 			ds = &reviewdog.EmptyDiff{}
 		} else {

--- a/cmd/reviewdog/main_test.go
+++ b/cmd/reviewdog/main_test.go
@@ -105,6 +105,40 @@ func TestRun_local_nofilter(t *testing.T) {
 	}
 }
 
+func TestRun_unified_nofilter(t *testing.T) {
+	var (
+		stdin = strings.Join([]string{
+			"/path/to/file(2,1): message1",
+			"/path/to/file(2): message2",
+			"/path/to/file(14,1): message3",
+		}, "\n")
+		want = `/path/to/file:2:1: [test] message1
+/path/to/file:14:1: [test] message3`
+	)
+
+	opt := &option{
+		diffCmd:   "", // empty
+		efms:      strslice([]string{`%f(%l,%c): %m`}),
+		diffStrip: 0,
+		reporter:  "unified",
+		name:      "test",
+	}
+
+	stdout := new(bytes.Buffer)
+	if err := run(strings.NewReader(stdin), stdout, opt); err == nil {
+		t.Errorf("got no error, but want error")
+	}
+
+	opt.filterMode = difffilter.ModeNoFilter
+	if err := run(strings.NewReader(stdin), stdout, opt); err != nil {
+		t.Error(err)
+	}
+
+	if got := strings.Trim(stdout.String(), "\n"); got != want {
+		t.Errorf("got:\n%v\n want\n%v", got, want)
+	}
+}
+
 func TestRun_local_tee(t *testing.T) {
 	stdin := "tee test"
 	opt := &option{


### PR DESCRIPTION
_This is my first time writing Go code, please be gentle and suggestions welcome :)_

Adds a Unified reporter which is the same as the local reporter but outputs in unified format.

**Use Case:** I want to use reviewdog as part of https://github.com/marketplace/actions/super-duper-linter but I want to handle the linter run, I just want reviewdog to take my completed output and provide me back it's formatted result from the EFM or built-in formats in a standard parseable format so I can serialize the results back and do some processing before punting it back to reviewdog to publish comments/notes to the PR.

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

