### PR TITLE
doghouse: Use shared http.RoundTripper

### DIFF
--- a/doghouse/appengine/checker.go
+++ b/doghouse/appengine/checker.go
@@ -9,12 +9,10 @@ import (
 	"net/url"
 	"strings"
 
-	"contrib.go.opencensus.io/exporter/stackdriver/propagation"
 	"github.com/reviewdog/reviewdog/doghouse"
 	"github.com/reviewdog/reviewdog/doghouse/server"
 	"github.com/reviewdog/reviewdog/doghouse/server/ciutil"
 	"github.com/reviewdog/reviewdog/doghouse/server/storage"
-	"go.opencensus.io/plugin/ochttp"
 )
 
 type githubChecker struct {
@@ -22,6 +20,7 @@ type githubChecker struct {
 	integrationID    int
 	ghInstStore      storage.GitHubInstallationStore
 	ghRepoTokenStore storage.GitHubRepositoryTokenStore
+	tr               http.RoundTripper
 }
 
 func (gc *githubChecker) handleCheck(w http.ResponseWriter, r *http.Request) {
@@ -48,10 +47,7 @@ func (gc *githubChecker) handleCheck(w http.ResponseWriter, r *http.Request) {
 		IntegrationID: gc.integrationID,
 		RepoOwner:     req.Owner,
 		Client: &http.Client{
-			Transport: &ochttp.Transport{
-				// Use Google Cloud propagation format.
-				Propagation: &propagation.HTTPFormat{},
-			},
+			Transport: gc.tr,
 		},
 	}
 

--- a/doghouse/appengine/main.go
+++ b/doghouse/appengine/main.go
@@ -86,6 +86,10 @@ func main() {
 		integrationID:    integrationID,
 		ghInstStore:      &ghInstStore,
 		ghRepoTokenStore: &ghRepoTokenStore,
+		tr: &ochttp.Transport{
+			// Use Google Cloud propagation format.
+			Propagation: &propagation.HTTPFormat{},
+		},
 	}
 
 	ghWebhookHandler := githubWebhookHandler{


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

// The provided tr http.RoundTripper should be shared between multiple
// installations to ensure reuse of underlying TCP connections.

https://github.com/bradleyfalzon/ghinstallation/blob/81f7095e75089d688962bb75ba9814748d90f004/transport.go#L72-L73