### PR TITLE
Use protojson to unmarshal rdjsonl 

### DIFF
--- a/_testdata/custom_rdjsonl.json
+++ b/_testdata/custom_rdjsonl.json
@@ -2,3 +2,5 @@
 {"message":"multiline test 2 (same line)","location":{"path":"_testdata/custom.txt","range":{"start":{"line":5}, "end":{"line":5}}}}
 {"message":"multiline test 3 (with line-break)","location":{"path":"_testdata/custom.txt","range":{"start":{"line":6,"column":2}, "end":{"line":7,"column":1}}}}
 {"message":"multiline test 4 (with line-break)","location":{"path":"_testdata/custom.txt","range":{"start":{"line":6,"column":2}, "end":{"line":9,"column":1}}}}
+{"message":"severity test 1","location":{"path":"_testdata/custom.txt","range":{"start":{"line":5, "column": 5}}}, "severity": "INFO"}
+{"message":"severity test 2","location":{"path":"_testdata/custom.txt","range":{"start":{"line":5, "column": 4}}}, "severity": 2}

--- a/parser.go
+++ b/parser.go
@@ -2,7 +2,6 @@ package reviewdog
 
 import (
 	"bufio"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"github.com/reviewdog/errorformat"
 	"github.com/reviewdog/errorformat/fmts"
 	"github.com/reviewdog/reviewdog/proto/rdf"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // ParserOpt represents option to create Parser. Either FormatName or
@@ -177,7 +177,7 @@ func (p *RDJSONLParser) Parse(r io.Reader) ([]*CheckResult, error) {
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		d := new(rdf.Diagnostic)
-		if err := json.Unmarshal(s.Bytes(), d); err != nil {
+		if err := protojson.Unmarshal(s.Bytes(), d); err != nil {
 			return nil, err
 		}
 		results = append(results, &CheckResult{Diagnostic: d, Lines: []string{s.Text()}})

--- a/parser_test.go
+++ b/parser_test.go
@@ -115,7 +115,9 @@ func TestRDJSONLParser(t *testing.T) {
 {"source":{"name":"deadcode"},"message":"'unused2' is unused","location":{"path":"testdata/main.go","range":{"start":{"line":24,"column":6}}}}
 {"source":{"name":"errcheck"},"message":"Error return value of 'os.Open' is not checked","location":{"path":"testdata/main.go","range":{"start":{"line":15,"column":9}}}}
 {"source":{"name":"ineffassign"},"message":"ineffectual assignment to 'x'","location":{"path":"testdata/main.go","range":{"start":{"line":12,"column":2}}}}
-{"source":{"name":"govet"},"message":"printf: Sprintf format %d reads arg #1, but call has 0 args","location":{"path":"testdata/main.go","range":{"start":{"line":13,"column":2}}}}`
+{"source":{"name":"govet"},"message":"printf: Sprintf format %d reads arg #1, but call has 0 args","location":{"path":"testdata/main.go","range":{"start":{"line":13,"column":2}}}}
+{"source":{"name":"severity-test"},"message":"severity test (string)","location":{"path":"testdata/main.go","range":{"start":{"line":24,"column":6}}}, "severity": "WARNING"}
+{"source":{"name":"severity-test"},"message":"severity test (number)","location":{"path":"testdata/main.go","range":{"start":{"line":24,"column":6}}}, "severity": "WARNING"}`
 	sampleLines := strings.Split(sample, "\n")
 	p := NewRDJSONLParser()
 	crs, err := p.Parse(strings.NewReader(sample))


### PR DESCRIPTION
protojson: https://pkg.go.dev/google.golang.org/protobuf/encoding/protojson

It supports unmarshaling ENUM both by number and enum name.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.