### PR TITLE
github-pr-review: fix rnd position with column == 1 handling

### DIFF
--- a/service/github/github.go
+++ b/service/github/github.go
@@ -152,11 +152,6 @@ func buildDraftReviewComment(c *reviewdog.Comment, body string) *github.DraftRev
 func githubCommentLine(c *reviewdog.Comment) int {
 	loc := c.Result.Diagnostic.GetLocation()
 	line := loc.GetRange().GetEnd().GetLine()
-	// End position with column == 1 means range to the end of the previous lines
-	// including line-break.
-	if loc.GetRange().GetEnd().GetColumn() == 1 {
-		line--
-	}
 	if line == 0 {
 		line = loc.GetRange().GetStart().GetLine()
 	}

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -284,7 +284,7 @@ func buildSingleSuggestion(c *reviewdog.Comment, s *rdf.Suggestion) (string, err
 		return "", fmt.Errorf("the Diagnostic's lines and Suggestion lines must be the same. %d-%d v.s. %d-%d",
 			drange.GetStart().GetLine(), drange.GetEnd().GetLine(), start.GetLine(), end.GetLine())
 	}
-	if start.GetColumn() > 1 || end.GetColumn() > 1 {
+	if start.GetColumn() > 0 || end.GetColumn() > 0 {
 		// TODO(haya14busa): Support non-line based suggestion.
 		return "", errors.New("non line based suggestions (contains column) are not supported yet")
 	}

--- a/service/github/github_test.go
+++ b/service/github/github_test.go
@@ -236,7 +236,7 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 				{
 					Path:      github.String("reviewdog.go"),
 					StartLine: github.Int(15),
-					Line:      github.Int(16),
+					Line:      github.Int(17),
 					Body:      github.String(commentutil.BodyPrefix + "\nmultiline existing comment (line-break)"),
 				},
 			}


### PR DESCRIPTION
It actually should use the end line as-is. For example, if a suggestion
want to remove line-break, the end line actually needs to be the line after
the line-break.


- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.