### PR TITLE
Remove reviewdog.Comment.Body

### DIFF
--- a/comment_iowriter.go
+++ b/comment_iowriter.go
@@ -51,7 +51,7 @@ func (mc *UnifiedCommentWriter) Post(_ context.Context, c *Comment) error {
 			s += fmt.Sprintf(":%d", start.GetColumn())
 		}
 	}
-	s += fmt.Sprintf(": [%s] %s", c.ToolName, c.Body)
+	s += fmt.Sprintf(": [%s] %s", c.ToolName, c.Result.Diagnostic.GetMessage())
 	_, err := fmt.Fprintln(mc.w, s)
 	return err
 }

--- a/comment_iowriter_test.go
+++ b/comment_iowriter_test.go
@@ -18,56 +18,64 @@ func TestUnifiedCommentWriter_Post(t *testing.T) {
 		{
 			in: &Comment{
 				Result: &filter.FilteredDiagnostic{
-					Diagnostic: &rdf.Diagnostic{Location: &rdf.Location{Path: "/path/to/file"}},
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{Path: "/path/to/file"},
+						Message:  "message",
+					},
 				},
 				ToolName: "tool name",
-				Body:     "message",
 			},
 			want: `/path/to/file: [tool name] message`,
 		},
 		{
 			in: &Comment{
 				Result: &filter.FilteredDiagnostic{
-					Diagnostic: &rdf.Diagnostic{Location: &rdf.Location{
-						Path: "/path/to/file",
-						Range: &rdf.Range{Start: &rdf.Position{
-							Column: 14,
-						}},
-					}},
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{
+							Path: "/path/to/file",
+							Range: &rdf.Range{Start: &rdf.Position{
+								Column: 14,
+							}},
+						},
+						Message: "message",
+					},
 				},
 				ToolName: "tool name",
-				Body:     "message",
 			},
 			want: `/path/to/file: [tool name] message`,
 		},
 		{
 			in: &Comment{
 				Result: &filter.FilteredDiagnostic{
-					Diagnostic: &rdf.Diagnostic{Location: &rdf.Location{
-						Path: "/path/to/file",
-						Range: &rdf.Range{Start: &rdf.Position{
-							Line: 14,
-						}},
-					}},
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{
+							Path: "/path/to/file",
+							Range: &rdf.Range{Start: &rdf.Position{
+								Line: 14,
+							}},
+						},
+						Message: "message",
+					},
 				},
 				ToolName: "tool name",
-				Body:     "message",
 			},
 			want: `/path/to/file:14: [tool name] message`,
 		},
 		{
 			in: &Comment{
 				Result: &filter.FilteredDiagnostic{
-					Diagnostic: &rdf.Diagnostic{Location: &rdf.Location{
-						Path: "/path/to/file",
-						Range: &rdf.Range{Start: &rdf.Position{
-							Line:   14,
-							Column: 7,
-						}},
-					}},
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{
+							Path: "/path/to/file",
+							Range: &rdf.Range{Start: &rdf.Position{
+								Line:   14,
+								Column: 7,
+							}},
+						},
+						Message: "line1\nline2",
+					},
 				},
 				ToolName: "tool name",
-				Body:     "line1\nline2",
 			},
 			want: `/path/to/file:14:7: [tool name] line1
 line2`,

--- a/reviewdog.go
+++ b/reviewdog.go
@@ -40,7 +40,6 @@ func RunFromResult(ctx context.Context, c CommentService, results []*rdf.Diagnos
 type Comment struct {
 	Result   *filter.FilteredDiagnostic
 	ToolName string
-	Body     string
 }
 
 // CommentService is an interface which posts Comment.
@@ -77,7 +76,6 @@ func (w *Reviewdog) runFromResult(ctx context.Context, results []*rdf.Diagnostic
 		}
 		comment := &Comment{
 			Result:   check,
-			Body:     check.Diagnostic.GetMessage(),
 			ToolName: w.toolname,
 		}
 		if err := w.c.Post(ctx, comment); err != nil {

--- a/service/commentutil/commentutil.go
+++ b/service/commentutil/commentutil.go
@@ -59,5 +59,5 @@ func CommentBody(c *reviewdog.Comment) string {
 	if c.ToolName != "" {
 		tool = fmt.Sprintf("**[%s]** ", c.ToolName)
 	}
-	return tool + BodyPrefix + "\n" + c.Body
+	return tool + BodyPrefix + "\n" + c.Result.Diagnostic.GetMessage()
 }

--- a/service/gerrit/change_review.go
+++ b/service/gerrit/change_review.go
@@ -75,7 +75,7 @@ func (g *ChangeReviewCommenter) postAllComments(ctx context.Context) error {
 		path := loc.GetPath()
 		review.Comments[path] = append(review.Comments[path], gerrit.CommentInput{
 			Line:    int(loc.GetRange().GetStart().GetLine()),
-			Message: c.Body,
+			Message: c.Result.Diagnostic.GetMessage(),
 		})
 	}
 

--- a/service/gerrit/change_review_test.go
+++ b/service/gerrit/change_review_test.go
@@ -38,10 +38,10 @@ func TestChangeReviewCommenter_Post_Flush(t *testing.T) {
 						Line: int32(newLnum1),
 					}},
 				},
+				Message: "new comment",
 			},
 			InDiffFile: true,
 		},
-		Body: "new comment",
 	}
 	newLnum2 := 15
 	newComment2 := &reviewdog.Comment{
@@ -53,10 +53,10 @@ func TestChangeReviewCommenter_Post_Flush(t *testing.T) {
 						Line: int32(newLnum2),
 					}},
 				},
+				Message: "new comment 2",
 			},
 			InDiffFile: true,
 		},
-		Body: "new comment 2",
 	}
 	commentOutsideDiff := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -67,10 +67,10 @@ func TestChangeReviewCommenter_Post_Flush(t *testing.T) {
 						Line: 14,
 					}},
 				},
+				Message: "comment outside diff",
 			},
 			InDiffFile: false,
 		},
-		Body: "comment outside diff",
 	}
 
 	comments := []*reviewdog.Comment{
@@ -93,13 +93,15 @@ func TestChangeReviewCommenter_Post_Flush(t *testing.T) {
 			}
 
 			line1 := int(newComment1.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine())
-			want := []gerrit.CommentInput{{Line: line1, Message: newComment1.Body}}
+			want := []gerrit.CommentInput{{
+				Line: line1, Message: newComment1.Result.Diagnostic.GetMessage()}}
 			if diff := cmp.Diff(got.Comments["file.go"], want); diff != "" {
 				t.Error(diff)
 			}
 
 			line2 := int(newComment2.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine())
-			want = []gerrit.CommentInput{{Line: line2, Message: newComment2.Body}}
+			want = []gerrit.CommentInput{{
+				Line: line2, Message: newComment2.Result.Diagnostic.GetMessage()}}
 			if diff := cmp.Diff(got.Comments["file2.go"], want); diff != "" {
 				t.Error(diff)
 			}

--- a/service/github/github_test.go
+++ b/service/github/github_test.go
@@ -77,10 +77,10 @@ func TestGitHubPullRequest_Post(t *testing.T) {
 				Location: &rdf.Location{
 					Path: "watchdogs.go",
 				},
+				Message: "[reviewdog] test",
 			},
 			InDiffContext: true,
 		},
-		Body: "[reviewdog] test",
 	}
 	// https://github.com/reviewdog/reviewdog/pull/2/files#diff-ed1d019a10f54464cfaeaf6a736b7d27L20
 	if err := g.Post(context.Background(), comment); err != nil {
@@ -353,10 +353,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							},
 						},
 					},
+					Message: "already commented",
 				},
 				InDiffContext: true,
 			},
-			Body: "already commented",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -369,10 +369,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							},
 						},
 					},
+					Message: "already commented 2",
 				},
 				InDiffContext: true,
 			},
-			Body: "already commented 2",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -385,10 +385,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							},
 						},
 					},
+					Message: "new comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "new comment",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -404,10 +404,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							},
 						},
 					},
+					Message: "multiline existing comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "multiline existing comment",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -425,10 +425,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							},
 						},
 					},
+					Message: "multiline existing comment (line-break)",
 				},
 				InDiffContext: true,
 			},
-			Body: "multiline existing comment (line-break)",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -444,10 +444,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							},
 						},
 					},
+					Message: "multiline new comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "multiline new comment",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -456,9 +456,9 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 						Path: "reviewdog.go",
 						// No Line
 					},
+					Message: "should not be reported via GitHub Review API",
 				},
 			},
-			Body: "should not be reported via GitHub Review API",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -487,10 +487,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							Text: "line1\nline2\nline3",
 						},
 					},
+					Message: "multiline suggestion comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "multiline suggestion comment",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -513,10 +513,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							Text: "line1\nline2",
 						},
 					},
+					Message: "singleline suggestion comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "singleline suggestion comment",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -545,10 +545,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							Text: "line1\nline2\nline3",
 						},
 					},
+					Message: "invalid lines suggestion comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "invalid lines suggestion comment",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -579,10 +579,10 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 							Text: "replacement",
 						},
 					},
+					Message: "non-line based suggestion comment",
 				},
 				InDiffContext: true,
 			},
-			Body: "non-line based suggestion comment",
 		},
 	}
 	for _, c := range comments {
@@ -647,10 +647,10 @@ func TestGitHubPullRequest_Post_toomany(t *testing.T) {
 							Line: int32(i),
 						}},
 					},
+					Message: "comment",
 				},
 				InDiffContext: true,
 			},
-			Body:     "comment",
 			ToolName: "tool",
 		})
 	}

--- a/service/gitlab/gitlab_mr_commit_test.go
+++ b/service/gitlab/gitlab_mr_commit_test.go
@@ -101,10 +101,10 @@ func TestGitLabMergeRequestCommitCommenter_Post_Flush_review_api(t *testing.T) {
 							Line: 1,
 						}},
 					},
+					Message: "already commented",
 				},
 				InDiffFile: true,
 			},
-			Body: "already commented",
 		},
 		{
 			Result: &filter.FilteredDiagnostic{
@@ -115,10 +115,10 @@ func TestGitLabMergeRequestCommitCommenter_Post_Flush_review_api(t *testing.T) {
 							Line: 14,
 						}},
 					},
+					Message: "new comment",
 				},
 				InDiffFile: true,
 			},
-			Body: "new comment",
 		},
 	}
 	for _, c := range comments {

--- a/service/gitlab/gitlab_mr_discussion_test.go
+++ b/service/gitlab/gitlab_mr_discussion_test.go
@@ -32,10 +32,10 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 						Line: 1,
 					}},
 				},
+				Message: "already commented",
 			},
 			InDiffFile: true,
 		},
-		Body: "already commented",
 	}
 	alreadyCommented2 := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -46,10 +46,10 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 						Line: 14,
 					}},
 				},
+				Message: "already commented 2",
 			},
 			InDiffFile: true,
 		},
-		Body: "already commented 2",
 	}
 	newComment1 := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -60,10 +60,10 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 						Line: 14,
 					}},
 				},
+				Message: "new comment",
 			},
 			InDiffFile: true,
 		},
-		Body: "new comment",
 	}
 	newComment2 := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -74,10 +74,10 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 						Line: 15,
 					}},
 				},
+				Message: "new comment 2",
 			},
 			InDiffFile: true,
 		},
-		Body: "new comment 2",
 	}
 	newComment3 := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -88,12 +88,12 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 						Line: 14,
 					}},
 				},
+				Message: "new comment 3",
 			},
 			OldPath:    "old_file.go",
 			OldLine:    7,
 			InDiffFile: true,
 		},
-		Body: "new comment 3",
 	}
 	commentOutsideDiff := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -104,10 +104,10 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 						Line: 14,
 					}},
 				},
+				Message: "comment outside diff",
 			},
 			InDiffFile: false,
 		},
-		Body: "comment outside diff",
 	}
 	commentWithoutLnum := &reviewdog.Comment{
 		Result: &filter.FilteredDiagnostic{
@@ -115,10 +115,10 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				Location: &rdf.Location{
 					Path: "path.go",
 				},
+				Message: "comment without lnum",
 			},
 			InDiffFile: true,
 		},
-		Body: "comment without lnum",
 	}
 
 	comments := []*reviewdog.Comment{


### PR DESCRIPTION
It's actually needless and each reporter should format the comment body.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.