### PR TITLE
github-check: Use external_id to associate check run with the correct workflow for GitHub Actions

### DIFF
--- a/cmd/reviewdog/doghouse.go
+++ b/cmd/reviewdog/doghouse.go
@@ -159,6 +159,7 @@ func postResultSet(ctx context.Context, resultSet *reviewdog.ResultMap,
 		return nil, err
 	}
 	externalID := maybeGetExternalID(ctx, ghInfo)
+	log.Printf("externalID: %s", externalID)
 	filteredResultSet := new(reviewdog.FilteredResultMap)
 	resultSet.Range(func(name string, result *reviewdog.Result) {
 		diagnostics := result.Diagnostics

--- a/doghouse/server/doghouse.go
+++ b/doghouse/server/doghouse.go
@@ -124,6 +124,9 @@ func (ch *Checker) createCheck(ctx context.Context) (*github.CheckRun, error) {
 		HeadSHA: ch.req.SHA,
 		Status:  github.String("in_progress"),
 	}
+	if ch.req.ExternalID != "" {
+		opt.ExternalID = github.String(ch.req.ExternalID)
+	}
 	return ch.gh.CreateCheckRun(ctx, ch.req.Owner, ch.req.Repo, opt)
 }
 

--- a/doghouse/server/doghouse.go
+++ b/doghouse/server/doghouse.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -127,6 +128,7 @@ func (ch *Checker) createCheck(ctx context.Context) (*github.CheckRun, error) {
 	if ch.req.ExternalID != "" {
 		opt.ExternalID = github.String(ch.req.ExternalID)
 	}
+	log.Printf("CheckRun.external_id: %s", ch.req.ExternalID)
 	return ch.gh.CreateCheckRun(ctx, ch.req.Owner, ch.req.Repo, opt)
 }
 

--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -49,6 +49,10 @@ type CheckRequest struct {
 	// FilterMode represents a way to filter checks results
 	// Optional.
 	FilterMode filter.Mode `json:"filter_mode"`
+
+	// Check suite external ID to associate with the check run.
+	// Optional.
+	ExternalID string `json:"external_id,omitempty"`
 }
 
 // CheckResponse represents doghouse GitHub check response.


### PR DESCRIPTION
ref: #403

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

