### PR TITLE
Allow GitHub PR reporting for a forked repository iff it's triggered by pull_request_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- ...
+- [#888](https://github.com/reviewdog/reviewdog/pull/888) Allow GitHub PR reporting for a forked repository iff it's triggered by `pull_request_target`
 
 ### :bug: Fixes
 - ...

--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -111,5 +111,6 @@ func HasReadOnlyPermissionGitHubToken() bool {
 	if err != nil {
 		return false
 	}
-	return event.PullRequest.Head.Repo.Owner.ID != event.PullRequest.Base.Repo.Owner.ID && event.ActionName != "pull_request_target"
+	isForkedRepo := event.PullRequest.Head.Repo.Owner.ID != event.PullRequest.Base.Repo.Owner.ID
+	return isForkedRepo && event.ActionName != "pull_request_target"
 }

--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -22,6 +22,7 @@ type GitHubEvent struct {
 	HeadCommit struct {
 		ID string `json:"id"`
 	} `json:"head_commit"`
+	ActionName string `json:"action_name"`
 }
 
 type GitHubRepo struct {
@@ -102,12 +103,13 @@ func IsInGitHubAction() bool {
 	return os.Getenv("GITHUB_ACTIONS") != ""
 }
 
-// IsGitHubPRFromForkedRepo returns true if reviewdog is running in GitHub
-// Actions and running for PullRequests from forked repository.
-func IsGitHubPRFromForkedRepo() bool {
+// HasReadOnlyPermissionGitHubToken returns true if reviewdog is running in GitHub
+// Actions and running for PullRequests from forked repository with read-only token.
+// https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+func HasReadOnlyPermissionGitHubToken() bool {
 	event, err := LoadGitHubEvent()
 	if err != nil {
 		return false
 	}
-	return event.PullRequest.Head.Repo.Owner.ID != event.PullRequest.Base.Repo.Owner.ID
+	return event.PullRequest.Head.Repo.Owner.ID != event.PullRequest.Base.Repo.Owner.ID && event.ActionName != "pull_request_target"
 }

--- a/cmd/reviewdog/doghouse.go
+++ b/cmd/reviewdog/doghouse.go
@@ -191,11 +191,12 @@ func checkResultToAnnotation(d *rdf.Diagnostic, wd, gitRelWd string) *doghouse.A
 // It returns true if reviewdog should exit with 1.
 // e.g. At least one annotation result is in diff.
 func reportResults(w io.Writer, filteredResultSet *reviewdog.FilteredResultMap) bool {
-	if filteredResultSet.Len() != 0 && cienv.IsGitHubPRFromForkedRepo() {
-		fmt.Fprintln(w, `reviewdog: This is Pull-Request from forked repository.
-GitHub token doesn't have write permission of Check API, so reviewdog will
-report results via logging command [1].
-[1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands`)
+	if filteredResultSet.Len() != 0 && cienv.HasReadOnlyPermissionGitHubToken() {
+		fmt.Fprintln(w, `reviewdog: This GitHub token doesn't have write permission of Review API [1], 
+so reviewdog will report results via logging command [2] and create annotations similar to
+github-pr-check reporter as a fallback.
+[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target, 
+[2]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands`)
 	}
 
 	// Sort names to get deterministic result.

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -280,12 +280,12 @@ func run(r io.Reader, w io.Writer, opt *option) error {
 		// instead of review comment because if it's PR from forked repository,
 		// GitHub token doesn't have write permission due to security concern and
 		// cannot post results via Review API.
-		if cienv.IsInGitHubAction() && cienv.IsGitHubPRFromForkedRepo() {
-			fmt.Fprintln(w, `reviewdog: This is Pull-Request from forked repository.
-GitHub token doesn't have write permission of Review API, so reviewdog will
-report results via logging command [1] and create annotations similar to
+		if cienv.IsInGitHubAction() && cienv.HasReadOnlyPermissionGitHubToken() {
+			fmt.Fprintln(w, `reviewdog: This GitHub token doesn't have write permission of Review API [1], 
+so reviewdog will report results via logging command [2] and create annotations similar to
 github-pr-check reporter as a fallback.
-[1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands`)
+[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target, 
+[2]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands`)
 			cs = githubutils.NewGitHubActionLogWriter(opt.level)
 		} else {
 			cs = reviewdog.MultiCommentService(gs, cs)


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Related to #706,  #759

This PR just allows the `pull_request_target` trigger even if it's from a forked repo. GITHUB_TOKEN via the trigger has enough read/write permission to call review APIs.