### PR TITLE
Use $default-branch instead of master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     branches:
-      - master
+      - $default-branch
       - release-*
     tags:
       - 'v*.*.*'

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,7 +2,7 @@ name: reviewdog
 on:
   push:
     branches:
-      - master
+      - $default-branch
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ name: reviewdog (github-check)
 on:
   push:
     branches:
-      - master
+      - $default-branch
   pull_request:
 
 jobs:


### PR DESCRIPTION
https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/
