### PR TITLE
treat GITHUB_API_URL env as same as GITHUB_API env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :rocket: Enhancements
 - [#888](https://github.com/reviewdog/reviewdog/pull/888) Allow GitHub PR reporting for a forked repository iff it's triggered by `pull_request_target`
+- [#976](https://github.com/reviewdog/reviewdog/pull/976) Treat `GITHUB_API_URL` environment variable as same as `GITHUB_API`, so users can use reviewdog in GitHub Actions in Enterprise Server without setting `GITHUB_API`
 
 ### :bug: Fixes
 - ...

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -538,6 +538,8 @@ func githubBaseURL() (*url.URL, error) {
 		}
 		return u, nil
 	}
+	// get GitHub base URL from GitHub Actions' default environment variable GITHUB_API_URL
+	// ref: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
 	if baseURL := os.Getenv("GITHUB_API_URL"); baseURL != "" {
 		u, err := url.Parse(baseURL + "/")
 		if err != nil {

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -539,7 +539,7 @@ func githubBaseURL() (*url.URL, error) {
 		return u, nil
 	}
 	if baseURL := os.Getenv("GITHUB_API_URL"); baseURL != "" {
-		u, err := url.Parse(baseURL)
+		u, err := url.Parse(baseURL + "/")
 		if err != nil {
 			return nil, fmt.Errorf("GitHub base URL from GITHUB_API_URL is invalid: %v, %w", baseURL, err)
 		}

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -531,13 +531,23 @@ func githubClient(ctx context.Context, token string) (*github.Client, error) {
 const defaultGitHubAPI = "https://api.github.com/"
 
 func githubBaseURL() (*url.URL, error) {
-	baseURL := os.Getenv("GITHUB_API")
-	if baseURL == "" {
-		baseURL = defaultGitHubAPI
+	if baseURL := os.Getenv("GITHUB_API"); baseURL != "" {
+		u, err := url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("GitHub base URL from GITHUB_API is invalid: %v, %w", baseURL, err)
+		}
+		return u, nil
 	}
-	u, err := url.Parse(baseURL)
+	if baseURL := os.Getenv("GITHUB_API_URL"); baseURL != "" {
+		u, err := url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("GitHub base URL from GITHUB_API_URL is invalid: %v, %w", baseURL, err)
+		}
+		return u, nil
+	}
+	u, err := url.Parse(defaultGitHubAPI)
 	if err != nil {
-		return nil, fmt.Errorf("GitHub base URL is invalid: %v, %w", baseURL, err)
+		return nil, fmt.Errorf("GitHub base URL from reviewdog default is invalid: %v, %w", defaultGitHubAPI, err)
 	}
 	return u, nil
 }


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

This PR make reviewdog treat `GITHUB_API_URL` environment variable as the same as `GITHUB_API`
Close: #975 
related: reviewdog/action-tflint#38, reviewdog/action-golangci-lint#81
