### PR TITLE
Bump Go 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.14
+        go-version: 1.16
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-go@v2
         if: "steps.tag.outputs.value != ''"
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       # Create release.
       - uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       - uses: actions/checkout@v2
 
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       - uses: actions/checkout@v2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reviewdog/reviewdog
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go v0.84.0

--- a/scripts/trigger-depup/go.mod
+++ b/scripts/trigger-depup/go.mod
@@ -1,6 +1,6 @@
 module github.com/reviewdog/reviewdog/scripts/trigger-depup
 
-go 1.14
+go 1.16
 
 require (
 	github.com/google/go-github/v35 v35.3.0


### PR DESCRIPTION
According to [Go Release Policy](https://golang.org/doc/devel/release#policy), Go v1.14 has been already unsupported.
We should update the latest version of Go, Go v1.16

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
