### PR TITLE
setup Go when we run goreleaser check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
 
       # Setup Go for building reviewdog binary.
       - uses: actions/setup-go@v2
-        if: "steps.tag.outputs.value != ''"
         with:
           go-version: 1.16
 


### PR DESCRIPTION
goreleaser warns darwin/arm64 will skip because goreleaser can't find Go 1.16.

https://github.com/reviewdog/reviewdog/runs/2956075029?check_suite_focus=true#step:7:22

> ```
>       • building binaries
>          • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
> ```

We need to setup Go 1.16 during not only building but also checking.

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

