### PR TITLE
use `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ $ brew install reviewdog/tap/reviewdog
 $ brew upgrade reviewdog/tap/reviewdog
 ```
 
-### Build from HEAD with go get
+### Build with go install
 
 ```shell
-$ go get -u github.com/reviewdog/reviewdog/cmd/reviewdog
+$ go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
 ```
 
 ## Input Format


### PR DESCRIPTION
using `go get` for installing commands will be deprecated.
we should use `go install` instead of it.

> https://tip.golang.org/doc/go1.17#go-get
> go get prints a deprecation warning when installing commands outside the main module (without the -d flag).
> go install cmd@version should be used instead to install a command at a specific version, using a suffix like @latest or @v1.2.3.
> In Go 1.18, the -d flag will always be enabled, and go get will only be used to change dependencies in go.mod.


- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

