### PR TITLE
Added support for Bitbucket Pipes within Pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- ...
-
-### :bug: Fixes
-- ...
-
-### :rotating_light: Breaking changes
-- ...
+- Added support for Bitbucket Pipes executed within Pipelines.
 
 ---
 

--- a/cienv/bitbucket_pipelines.go
+++ b/cienv/bitbucket_pipelines.go
@@ -7,3 +7,9 @@ func IsInBitbucketPipeline() bool {
 	// https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Default-variables
 	return os.Getenv("BITBUCKET_PIPELINE_UUID") != ""
 }
+
+// IsInBitbucketPipe returns true if reviewdog is running in a Bitbucket Pipe.
+func IsInBitbucketPipe() bool {
+	//
+	return os.Getenv("BITBUCKET_PIPE_STORAGE_DIR") != ""
+}

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -628,7 +628,7 @@ func bitbucketBuildWithClient(ctx context.Context) (*cienv.BuildInfo, *bitbucket
 		ctx = bbservice.WithAccessToken(ctx, bbAccessToken)
 	}
 
-	client := bbservice.NewAPIClient(cienv.IsInBitbucketPipeline())
+	client := bbservice.NewAPIClient(cienv.IsInBitbucketPipeline(), cienv.IsInBitbucketPipe())
 	return build, client, ctx, nil
 }
 

--- a/service/bitbucket/bitbucket.go
+++ b/service/bitbucket/bitbucket.go
@@ -18,7 +18,7 @@ const (
 	// https://support.atlassian.com/bitbucket-cloud/docs/code-insights/#Authentication
 	// However, if using proxy HTTP API endpoint need to be used
 	pipelineProxyURL = "http://localhost:29418"
-	// PipeProxyURL is to be used when reviewdog is running withing a Bitbucket Pipe
+	// PipeProxyURL is to be used when reviewdog is running within a Bitbucket Pipe
 	// Pipes run in docker containers and as a result will need to connect to the proxy via this Docker DNS.
 	pipeProxyURL = "http://host.docker.internal:29418"
 	httpTimeout  = time.Second * 10

--- a/service/bitbucket/bitbucket.go
+++ b/service/bitbucket/bitbucket.go
@@ -18,20 +18,30 @@ const (
 	// https://support.atlassian.com/bitbucket-cloud/docs/code-insights/#Authentication
 	// However, if using proxy HTTP API endpoint need to be used
 	pipelineProxyURL = "http://localhost:29418"
-	httpTimeout      = time.Second * 10
+	// PipeProxyURL is to be used when reviewdog is running withing a Bitbucket Pipe
+	// Pipes run in docker containers and as a result will need to connect to the proxy via this Docker DNS.
+	pipeProxyURL = "http://host.docker.internal:29418"
+	httpTimeout  = time.Second * 10
 )
 
 // NewAPIClient creates Bitbucket API client
-func NewAPIClient(isInPipeline bool) *bbapi.APIClient {
+func NewAPIClient(isInPipeline bool, isInPipe bool) *bbapi.APIClient {
 	httpClient := &http.Client{
 		Timeout: httpTimeout,
 	}
 	server := httpsServer()
 
 	if isInPipeline {
-		// if we are on the Bitbucket Pipeline, use HTTP endpoint
-		// and proxy
-		proxyURL, _ := url.Parse(pipelineProxyURL)
+		var proxyURL *url.URL
+		if isInPipe {
+			// if we are executing a pipe within a pipeline, use docker endpoint
+			// and proxy
+			proxyURL, _ = url.Parse(pipeProxyURL)
+		} else {
+			// if we are on the Bitbucket Pipeline, use HTTP endpoint
+			// and proxy
+			proxyURL, _ = url.Parse(pipelineProxyURL)
+		}
 		server = httpServer()
 		httpClient.Transport = &http.Transport{
 			Proxy: http.ProxyURL(proxyURL),


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Added support for Bitbucket pipes (equivalent of GitHub Actions).

Ran into a few problems trying to get this running, and confirmed with the Bitbucket team that I needed to be using the docker proxy when running within a pipe.

In regards to the environment variable `BITBUCKET_PIPE_STORAGE_DIR` I have also confirmed with the pipelines team that this is a valid environment variable to check against, at least until they add a more explicit env var to check against.
