### PR TITLE
fix(github): detect pr_target

### DIFF
--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -22,7 +22,7 @@ type GitHubEvent struct {
 	HeadCommit struct {
 		ID string `json:"id"`
 	} `json:"head_commit"`
-	ActionName string `json:"-"`
+	ActionName string `json:"-"` // env GITHUB_EVENT_NAME
 }
 
 type GitHubRepo struct {

--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-// https://help.github.com/en/articles/virtual-environments-for-github-actions#default-environment-variables
+// https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
 type GitHubEvent struct {
 	PullRequest GitHubPullRequest `json:"pull_request"`
 	Repository  struct {
@@ -22,7 +22,7 @@ type GitHubEvent struct {
 	HeadCommit struct {
 		ID string `json:"id"`
 	} `json:"head_commit"`
-	ActionName string `json:"-"` // env GITHUB_EVENT_NAME
+	ActionName string `json:"-"` // this is defined as env GITHUB_EVENT_NAME
 }
 
 type GitHubRepo struct {

--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -22,7 +22,7 @@ type GitHubEvent struct {
 	HeadCommit struct {
 		ID string `json:"id"`
 	} `json:"head_commit"`
-	ActionName string `json:"action_name"`
+	ActionName string `json:"-"`
 }
 
 type GitHubRepo struct {
@@ -62,6 +62,7 @@ func loadGitHubEventFromPath(eventPath string) (*GitHubEvent, error) {
 	if err := json.NewDecoder(f).Decode(&event); err != nil {
 		return nil, err
 	}
+	event.ActionName = os.Getenv("GITHUB_EVENT_NAME")
 	return &event, nil
 }
 


### PR DESCRIPTION
this should fix #1010

I don't know why `action_name` is removed from the `GITHUB_EVENT_PATH`, but it's documented as env `GITHUB_EVENT_NAME` now

And sorry, I'm new here, could anyone help me with the changelog? How should I add this.