### PR TITLE
Fix suggestion includes fenced code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :bug: Fixes
 - [#1014](https://github.com/reviewdog/reviewdog/pull/1014) Fix incorrect detection of the `GITHUB_TOKEN` permissions. fixes [#1010](https://github.com/reviewdog/reviewdog/issues/1010)
+- [#1017](https://github.com/reviewdog/reviewdog/pull/1017) Fix suggestions that include fenced code blocks. fixes [#999](https://github.com/reviewdog/reviewdog/issues/999)
 
 ### :rotating_light: Breaking changes
 - ...

--- a/service/commentutil/code_fence.go
+++ b/service/commentutil/code_fence.go
@@ -2,7 +2,11 @@ package commentutil
 
 import "io"
 
-// GetCodeFenceLength returns the length of a code fence that wraps code.
+// GetCodeFenceLength returns the length of a code fence needed to wrap code.
+// A test suggestion that uses four backticks w/o code fence block.
+// Fixes: https://github.com/reviewdog/reviewdog/issues/999
+//
+// Code fenced blocks are supported by GitHub Flavor Markdown.
 // A code fence is typically three backticks.
 //
 //     ```

--- a/service/commentutil/code_fence.go
+++ b/service/commentutil/code_fence.go
@@ -1,0 +1,80 @@
+package commentutil
+
+import "io"
+
+// GetCodeFenceLength returns the length of a code fence that wraps code.
+// A code fence is typically three backticks.
+//
+//     ```
+//     code
+//     ```
+//
+// However, we sometimes need more backticks.
+// https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks
+//
+// > To display triple backticks in a fenced code block, wrap them inside quadruple backticks.
+// >
+// >     ````
+// >     ```
+// >     Look! You can see my backticks.
+// >     ```
+// >     ````
+func GetCodeFenceLength(code string) int {
+	backticks := countBackticks(code) + 1
+	if backticks < 3 {
+		// At least three backticks are required.
+		// https://github.github.com/gfm/#fenced-code-blocks
+		// > A code fence is a sequence of at least three consecutive backtick characters (`) or tildes (~). (Tildes and backticks cannot be mixed.)
+		backticks = 3
+	}
+	return backticks
+}
+
+// WriteCodeFence writes a code fence to w.
+func WriteCodeFence(w io.Writer, length int) error {
+	if w, ok := w.(io.ByteWriter); ok {
+		// use WriteByte instead of Write to avoid memory allocation.
+		for i := 0; i < length; i++ {
+			if err := w.WriteByte('`'); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	buf := make([]byte, length)
+	for i := range buf {
+		buf[i] = '`'
+	}
+	_, err := w.Write(buf)
+	return err
+}
+
+// find code fences in s, and returns the maximum length of them.
+func countBackticks(s string) int {
+	inBackticks := true
+
+	var count int
+	var maxCount int
+	for _, r := range s {
+		if inBackticks {
+			if r == '`' {
+				count++
+			} else {
+				inBackticks = false
+				if count > maxCount {
+					maxCount = count
+				}
+				count = 0
+			}
+		}
+		if r == '\n' {
+			inBackticks = true
+			count = 0
+		}
+	}
+	if count > maxCount {
+		maxCount = count
+	}
+	return maxCount
+}

--- a/service/commentutil/code_fence_test.go
+++ b/service/commentutil/code_fence_test.go
@@ -1,0 +1,86 @@
+package commentutil
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestGetCodeFenceLength(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int
+	}{
+		{
+			in:   "",
+			want: 3,
+		},
+		{
+			in:   "`inline code`",
+			want: 3,
+		},
+		{
+			in:   "``foo`bar``",
+			want: 3,
+		},
+		{
+			in:   "func main() {\nprintln(\"Hello World\")\n}\n",
+			want: 3,
+		},
+		{
+			in:   "```\nLook! You can see my backticks.\n```\n",
+			want: 4,
+		},
+		{
+			in:   "```go\nfunc main() {\nprintln(\"Hello World\")\n}\n```",
+			want: 4,
+		},
+		{
+			in:   "```go\nfunc main() {\nprintln(\"Hello World\")\n}\n`````",
+			want: 6,
+		},
+		{
+			in:   "`````\n````\n```",
+			want: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		want := tt.want
+		if got := GetCodeFenceLength(tt.in); got != want {
+			t.Errorf("got unexpected length.\ngot:\n%d\nwant:\n%d", got, want)
+		}
+	}
+}
+
+// A version of strings.Builder without WriteByte
+type Builder struct {
+	strings.Builder
+	io.ByteWriter // conflicts with and hides strings.Builder's WriteByte.
+}
+
+func TestWriteCodeFence(t *testing.T) {
+	var buf Builder
+	err := WriteCodeFence(&buf, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "``````````"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteCodeFenceWriteByte(t *testing.T) {
+	var buf strings.Builder
+	err := WriteCodeFence(&buf, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "``````````"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -415,10 +415,11 @@ func countBackticks(s string) int {
 				}
 				count = 0
 			}
-		} else if r == '\n' {
-			inBackticks = true
 		}
-		// skip other runes
+		if r == '\n' {
+			inBackticks = true
+			count = 0
+		}
 	}
 	if count > maxCount {
 		maxCount = count

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -310,7 +310,7 @@ func buildSingleSuggestion(c *reviewdog.Comment, s *rdf.Suggestion) (string, err
 		return buildNonLineBasedSuggestion(c, s)
 	}
 
-	// If the suggestion includes triple backticks ("```"), we need to wrap them inside quadruple backticks.
+A test suggestion that uses four backticks w/o code fence block.
 	// https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks
 	//
 	// > To display triple backticks in a fenced code block, wrap them inside quadruple backticks.

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -310,8 +310,6 @@ func buildSingleSuggestion(c *reviewdog.Comment, s *rdf.Suggestion) (string, err
 		return buildNonLineBasedSuggestion(c, s)
 	}
 
-	// A test suggestion that uses four backticks w/o code fence block.
-	// Fixes: https://github.com/reviewdog/reviewdog/issues/999
 	txt := s.GetText()
 	backticks := commentutil.GetCodeFenceLength(txt)
 

--- a/service/github/github_test.go
+++ b/service/github/github_test.go
@@ -434,6 +434,48 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 					"```",
 				}, "\n") + "\n"),
 			},
+			{
+				Path:      github.String("reviewdog.go"),
+				Side:      github.String("RIGHT"),
+				StartSide: github.String("RIGHT"),
+				StartLine: github.Int(15),
+				Line:      github.Int(16),
+				Body: github.String(commentutil.BodyPrefix + strings.Join([]string{
+					"multiline suggestion comment including a code fence block",
+					"````suggestion",
+					"```",
+					"some code",
+					"```",
+					"````",
+				}, "\n") + "\n"),
+			},
+			{
+				Path: github.String("reviewdog.go"),
+				Side: github.String("RIGHT"),
+				Line: github.Int(15),
+				Body: github.String(commentutil.BodyPrefix + strings.Join([]string{
+					"singleline suggestion comment including a code fence block",
+					"````suggestion",
+					"```",
+					"some code",
+					"```",
+					"````",
+				}, "\n") + "\n"),
+			},
+			{
+				Path:      github.String("reviewdog.go"),
+				Side:      github.String("RIGHT"),
+				StartSide: github.String("RIGHT"),
+				StartLine: github.Int(15),
+				Line:      github.Int(16),
+				Body: github.String(commentutil.BodyPrefix + strings.Join([]string{
+					"multiline suggestion comment including an empty code fence block",
+					"``````suggestion",
+					"```",
+					"`````",
+					"``````",
+				}, "\n") + "\n"),
+			},
 		}
 		if diff := pretty.Compare(want, req.Comments); diff != "" {
 			t.Errorf("req.Comments diff: (-got +want)\n%s", diff)
@@ -941,6 +983,96 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 						},
 					},
 					Message: "range suggestion with start only location",
+				},
+				InDiffContext: true,
+			},
+		},
+		{
+			Result: &filter.FilteredDiagnostic{
+				Diagnostic: &rdf.Diagnostic{
+					Location: &rdf.Location{
+						Path: "reviewdog.go",
+						Range: &rdf.Range{
+							Start: &rdf.Position{
+								Line: 15,
+							},
+							End: &rdf.Position{
+								Line: 16,
+							},
+						},
+					},
+					Suggestions: []*rdf.Suggestion{
+						{
+							Range: &rdf.Range{
+								Start: &rdf.Position{
+									Line: 15,
+								},
+								End: &rdf.Position{
+									Line: 16,
+								},
+							},
+							Text: "```\nsome code\n```",
+						},
+					},
+					Message: "multiline suggestion comment including a code fence block",
+				},
+				InDiffContext: true,
+			},
+		},
+		{
+			Result: &filter.FilteredDiagnostic{
+				Diagnostic: &rdf.Diagnostic{
+					Location: &rdf.Location{
+						Path: "reviewdog.go",
+						Range: &rdf.Range{
+							Start: &rdf.Position{
+								Line: 15,
+							},
+						},
+					},
+					Suggestions: []*rdf.Suggestion{
+						{
+							Range: &rdf.Range{
+								Start: &rdf.Position{
+									Line: 15,
+								},
+							},
+							Text: "```\nsome code\n```",
+						},
+					},
+					Message: "singleline suggestion comment including a code fence block",
+				},
+				InDiffContext: true,
+			},
+		},
+		{
+			Result: &filter.FilteredDiagnostic{
+				Diagnostic: &rdf.Diagnostic{
+					Location: &rdf.Location{
+						Path: "reviewdog.go",
+						Range: &rdf.Range{
+							Start: &rdf.Position{
+								Line: 15,
+							},
+							End: &rdf.Position{
+								Line: 16,
+							},
+						},
+					},
+					Suggestions: []*rdf.Suggestion{
+						{
+							Range: &rdf.Range{
+								Start: &rdf.Position{
+									Line: 15,
+								},
+								End: &rdf.Position{
+									Line: 16,
+								},
+							},
+							Text: "```\n`````",
+						},
+					},
+					Message: "multiline suggestion comment including an empty code fence block",
 				},
 				InDiffContext: true,
 			},


### PR DESCRIPTION
When reviewdog suggests the following code

> ```
> original code
> ```

modified as

> ````
> reviewdog suggestion
> ```
> some code
> ```
> ````

the suggestion comment should be

> ````diff 
> -original code
> +reviewdog suggestion
> +```
> +some code
> +```
> ````

but actually, reviewdog suggests the following comment:

> ```diff
> -original code
> +reviewdog suggestion
> ```
> some code
> ```
> ```

This is because the markdown parser creates wrong pairs of code fences.

> ````markdown
> ```suggestion 
> reviewdog suggestion
> ```
> some code
> ```
> ```
> ````

The document of GitHub markdown says that it is needed to wrap them inside quadruple backticks in this case.
https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks

> To display triple backticks in a fenced code block, wrap them inside quadruple backticks.

> `````markdown
> ````suggestion 
> reviewdog suggestion
> ```
> some code
> ```
> ````
> `````

This pull request checks whether the suggestion includes code fences, and use quadruple backticks code fences if it is necessary.

Fixes https://github.com/reviewdog/reviewdog/issues/999

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

