### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-doghouse.yml
+++ b/.github/workflows/deploy-doghouse.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,6 +19,8 @@ jobs:
           go-version: 1.15
       - run: go test -v -race  ./...
   deploy:
+    permissions:
+      contents: read
     needs: [test]
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,8 @@ on: [push,pull_request]
 jobs:
 
   test:
+    permissions:
+      contents: read
     name: Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
@@ -65,6 +68,9 @@ jobs:
         run: go run ./scripts/trigger-depup/main.go
 
   release-check:
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   reviewdog-github-check:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     name: reviewdog (github-check)
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +48,10 @@ jobs:
             reviewdog -name="custom-rdjson" -f=rdjson -reporter=github-check -level=info
 
   reviewdog-pr:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     if: github.event_name == 'pull_request'
     name: reviewdog on Pull Request
     runs-on: ubuntu-latest
@@ -167,6 +175,10 @@ jobs:
             reviewdog -name="gofmt" -f=diff -f.diff.strip=0 -reporter=github-pr-review
 
   golangci-lint:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     if: github.event_name == 'pull_request'
     name: runner / golangci-lint
     runs-on: ubuntu-latest
@@ -180,6 +192,10 @@ jobs:
           reporter: github-pr-check
 
   staticcheck:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     if: github.event_name == 'pull_request'
     name: runner / staticcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

GitHub provides a [feature](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) to set permissions for the GITHUB_TOKEN. I have implemented a [GitHub App](https://github.com/apps/step-security) to automatically calculate the right permissions for a given workflow.  

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows.  

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. Please try it out on other repos and share your feedback. Thanks!

- [X] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

