### PR TITLE
GitHub Action for TypeScript Compiler (tsc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,8 @@ You can use public GitHub Actions to start using reviewdog with ease! :tada: :ar
   - [reviewdog/action-golangci-lint](https://github.com/reviewdog/action-golangci-lint) - Run [golangci-lint](https://github.com/golangci/golangci-lint) and supported linters individually by golangci-lint.
 - JavaScript
   - [reviewdog/action-eslint](https://github.com/reviewdog/action-eslint) - Run [eslint](https://github.com/eslint/eslint).
+- TypeScript
+  - [EPMatt/reviewdog-action-tsc](https://github.com/EPMatt/reviewdog-action-tsc) - Run [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html).
 - CSS
   - [reviewdog/action-stylelint](https://github.com/reviewdog/action-stylelint) - Run [stylelint](https://github.com/stylelint/stylelint).
 - Vim script


### PR DESCRIPTION
Hi there,

first of all I really want to spend some words to thank @haya14busa and all the reviewdog contributors for bringing such a powerful and useful code review tool to the dev community. What staggers me the most is its ease of use and the large and growing number of supported code quality tools, linters etc. Keep going! 🚀 

While looking at the built-in error formats I noticed tsc was supported by reviewdog, but no GitHub Action was available for it...so I built one. :)

The action is available [here](https://github.com/EPMatt/reviewdog-action-tsc). If you have any suggestion or improvement, I'd be happy to hear your opinion. :)
This PR just adds a link to the action's repository to the list of public reviewdog GitHub Actions, provided in the README file.

Thank you! 

- [X] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

