### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/reviewdog/doghouse_test.go
+++ b/cmd/reviewdog/doghouse_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,7 +137,7 @@ func TestDiagnosticResultSet_Project(t *testing.T) {
 		return &wantDiagnosticResult, nil
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -732,7 +731,7 @@ func readConf(conf string) ([]byte, error) {
 		}
 	}
 	for _, f := range conffiles {
-		bytes, err := ioutil.ReadFile(f)
+		bytes, err := os.ReadFile(f)
 		if err == nil {
 			return bytes, nil
 		}

--- a/cmd/reviewdog/main_test.go
+++ b/cmd/reviewdog/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,13 +24,13 @@ line3
 `
 	)
 
-	beforef, err := ioutil.TempFile("", "reviewdog-test")
+	beforef, err := os.CreateTemp("", "reviewdog-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer beforef.Close()
 	defer os.Remove(beforef.Name())
-	afterf, err := ioutil.TempFile("", "reviewdog-test")
+	afterf, err := os.CreateTemp("", "reviewdog-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +153,7 @@ func TestRun_project(t *testing.T) {
 	})
 
 	t.Run("invalid config", func(t *testing.T) {
-		conffile, err := ioutil.TempFile("", "reviewdog-test")
+		conffile, err := os.CreateTemp("", "reviewdog-test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -175,7 +174,7 @@ func TestRun_project(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		conffile, err := ioutil.TempFile("", "reviewdog-test")
+		conffile, err := os.CreateTemp("", "reviewdog-test")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/diff_test.go
+++ b/diff_test.go
@@ -2,7 +2,7 @@ package reviewdog
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -40,7 +40,7 @@ index 34cacb9..a727dd3 100644
 }
 
 func TestDiffCmd(t *testing.T) {
-	wantb, err := ioutil.ReadFile("./diff/testdata/golint.diff")
+	wantb, err := os.ReadFile("./diff/testdata/golint.diff")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/doghouse/appengine/github.go
+++ b/doghouse/appengine/github.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -194,7 +193,7 @@ func (g *GitHubHandler) requestAccessToken(ctx context.Context, code, state stri
 	}
 	defer res.Body.Close()
 
-	b, _ := ioutil.ReadAll(res.Body)
+	b, _ := io.ReadAll(res.Body)
 
 	var token struct {
 		AccessToken string `json:"access_token"`

--- a/doghouse/appengine/main.go
+++ b/doghouse/appengine/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -37,7 +36,7 @@ func mustCookieMan() *cookieman.CookieMan {
 
 func mustGitHubAppsPrivateKey() []byte {
 	// Private keys https://github.com/settings/apps/reviewdog
-	githubAppsPrivateKey, err := ioutil.ReadFile(mustGetenv("GITHUB_PRIVATE_KEY_FILE"))
+	githubAppsPrivateKey, err := os.ReadFile(mustGetenv("GITHUB_PRIVATE_KEY_FILE"))
 	if err != nil {
 		log.Fatalf("could not read private key: %s", err)
 	}

--- a/doghouse/client/client.go
+++ b/doghouse/client/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -68,7 +68,7 @@ func (c *DogHouseClient) Check(ctx context.Context, req *doghouse.CheckRequest) 
 	}
 	defer httpResp.Body.Close()
 
-	respb, err := ioutil.ReadAll(httpResp.Body)
+	respb, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/doghouse/server/github_checker.go
+++ b/doghouse/server/github_checker.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/google/go-github/v39/github"
@@ -38,7 +38,7 @@ func (c *checkerGitHubClient) UpdateCheckRun(ctx context.Context, owner, repo st
 		checkRun, resp, err1 := c.Checks.UpdateCheckRun(ctx, owner, repo, checkID, opt)
 		if err1 != nil {
 			err = err1
-			b, err1 := ioutil.ReadAll(resp.Body)
+			b, err1 := io.ReadAll(resp.Body)
 			if err1 != nil {
 				aelog.Errorf(ctx, "failed to read error response body: %v", err1)
 			}

--- a/parser/rdjson.go
+++ b/parser/rdjson.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -22,7 +21,7 @@ func NewRDJSONParser() *RDJSONParser {
 
 // Parse parses rdjson (JSON of DiagnosticResult).
 func (p *RDJSONParser) Parse(r io.Reader) ([]*rdf.Diagnostic, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/service/bitbucket/cloud_api_client.go
+++ b/service/bitbucket/cloud_api_client.go
@@ -3,7 +3,7 @@ package bitbucket
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -118,7 +118,7 @@ func (c *CloudAPIClient) checkAPIError(err error, resp *http.Response, expectedC
 	}
 
 	if resp != nil && resp.StatusCode != expectedCode {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 
 		return UnexpectedResponseError{
 			Code: resp.StatusCode,

--- a/service/bitbucket/server_api_client.go
+++ b/service/bitbucket/server_api_client.go
@@ -3,7 +3,7 @@ package bitbucket
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	insights "github.com/reva2/bitbucket-insights-api"
@@ -87,7 +87,7 @@ func (c *ServerAPIClient) checkAPIError(err error, resp *http.Response, expected
 	}
 
 	if resp != nil && resp.StatusCode != expectedCode {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 
 		return UnexpectedResponseError{
 			Code: resp.StatusCode,


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.