### PR TITLE
Add action-black to public plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ You can use public GitHub Actions to start using reviewdog with ease! :tada: :ar
   - [tsuyoshicho/action-mypy](https://github.com/tsuyoshicho/action-mypy) - Run [mypy](https://pypi.org/project/mypy/)
   - [jordemort/action-pyright](https://github.com/jordemort/action-pyright) - Run [pyright](https://github.com/Microsoft/pyright)
   - [dciborow/action-pylint](https://github.com/dciborow/action-pylint) - Run [pyright](https://github.com/PyCQA/pylint)
+  - [reviewdog/action-black](https://github.com/reviewdog/action-black) - Run [black](https://github.com/psf/black)
 - Kotlin
   - [ScaCap/action-ktlint](https://github.com/ScaCap/action-ktlint) - Run [ktlint](https://ktlint.github.io/).
 - Android Lint


### PR DESCRIPTION
Just noticed https://github.com/reviewdog/action-black was missing from the list, whilst making some PRs over there.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

