### PR TITLE
Bump version: support end line/column errorformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.14.0] - 2022-02-11
 
 ### :rocket: Enhancements
-- [#1118](https://github.com/reviewdog/reviewdog/pull/1118) Suport end_lnum (%e) and end_col (%k) errorformat
+- [#1118](https://github.com/reviewdog/reviewdog/pull/1118) Support end_lnum (%e) and end_col (%k) errorformat
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :rotating_light: Breaking changes
 - ...
 
+## [v0.14.0] - 2022-02-11
+
+### :rocket: Enhancements
+- [#1118](https://github.com/reviewdog/reviewdog/pull/1118) Suport end_lnum (%e) and end_col (%k) errorformat
+
+---
+
 ## [v0.13.1] - 2021-12-28
 
 ### :rocket: Enhancements
-- [#1012](https://github.com/reviewdog/reviewdog/pull/1012) Use GitLab suggestions in merge request comments 
+- [#1012](https://github.com/reviewdog/reviewdog/pull/1012) Use GitLab suggestions in merge request comments
 
 ### :bug: Fixes
 - [#1014](https://github.com/reviewdog/reviewdog/pull/1014) Fix incorrect detection of the `GITHUB_TOKEN` permissions. fixes [#1010](https://github.com/reviewdog/reviewdog/issues/1010)
@@ -127,4 +134,5 @@ See https://github.com/reviewdog/reviewdog/releases for older release note.
 [v0.12.0]: https://github.com/reviewdog/reviewdog/compare/v0.11.0...v0.12.0
 [v0.13.0]: https://github.com/reviewdog/reviewdog/compare/v0.12.0...v0.13.0
 [v0.13.1]: https://github.com/reviewdog/reviewdog/compare/v0.13.0...v0.13.1
+[v0.14.0]: https://github.com/reviewdog/reviewdog/compare/v0.13.1...v0.14.0
 [@haya14busa]: https://github.com/haya14busa


### PR DESCRIPTION

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

