### PR TITLE
Allow BITBUCKET_SERVER_URL to have subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ...
 
 ### :bug: Fixes
+- [#1125](https://github.com/reviewdog/reviewdog/pull/1125) Allow BITBUCKET_SERVER_URL to have subpath
 - ...
 
 ### :rotating_light: Breaking changes

--- a/service/bitbucket/cloud_api_client.go
+++ b/service/bitbucket/cloud_api_client.go
@@ -114,7 +114,7 @@ func (c *CloudAPIClient) CreateOrUpdateAnnotations(ctx context.Context, req *Ann
 
 func (c *CloudAPIClient) checkAPIError(err error, resp *http.Response, expectedCode int) error {
 	if err != nil {
-		return fmt.Errorf("Bitbucket Cloud API error: %w", err)
+		return fmt.Errorf("bitbucket Cloud API error: %w", err)
 	}
 
 	if resp != nil && resp.StatusCode != expectedCode {

--- a/service/bitbucket/cloud_api_client.go
+++ b/service/bitbucket/cloud_api_client.go
@@ -106,7 +106,7 @@ func (c *CloudAPIClient) CreateOrUpdateAnnotations(ctx context.Context, req *Ann
 		Execute()
 
 	if err := c.checkAPIError(err, resp, http.StatusOK); err != nil {
-		return fmt.Errorf("failed to create code insighsts annotations: %w", err)
+		return fmt.Errorf("failed to create code insights annotations: %w", err)
 	}
 
 	return nil
@@ -114,7 +114,7 @@ func (c *CloudAPIClient) CreateOrUpdateAnnotations(ctx context.Context, req *Ann
 
 func (c *CloudAPIClient) checkAPIError(err error, resp *http.Response, expectedCode int) error {
 	if err != nil {
-		return fmt.Errorf("bitubucket API error: %w", err)
+		return fmt.Errorf("Bitbucket Cloud API error: %w", err)
 	}
 
 	if resp != nil && resp.StatusCode != expectedCode {

--- a/service/bitbucket/server_api_client.go
+++ b/service/bitbucket/server_api_client.go
@@ -75,7 +75,7 @@ func (c *ServerAPIClient) deleteReport(ctx context.Context, report *ReportReques
 		Execute()
 
 	if err := c.checkAPIError(err, resp, http.StatusNoContent); err != nil {
-		return fmt.Errorf("failted to delete code insights report: %w", err)
+		return fmt.Errorf("failed to delete code insights report: %w", err)
 	}
 
 	return nil
@@ -83,7 +83,7 @@ func (c *ServerAPIClient) deleteReport(ctx context.Context, report *ReportReques
 
 func (c *ServerAPIClient) checkAPIError(err error, resp *http.Response, expectedCode int) error {
 	if err != nil {
-		return fmt.Errorf("bitubucket API error: %w", err)
+		return fmt.Errorf("Bitbucket Server API error: %w", err)
 	}
 
 	if resp != nil && resp.StatusCode != expectedCode {

--- a/service/bitbucket/server_api_client.go
+++ b/service/bitbucket/server_api_client.go
@@ -83,7 +83,7 @@ func (c *ServerAPIClient) deleteReport(ctx context.Context, report *ReportReques
 
 func (c *ServerAPIClient) checkAPIError(err error, resp *http.Response, expectedCode int) error {
 	if err != nil {
-		return fmt.Errorf("Bitbucket Server API error: %w", err)
+		return fmt.Errorf("bitbucket Server API error: %w", err)
 	}
 
 	if resp != nil && resp.StatusCode != expectedCode {

--- a/service/bitbucket/server_api_context.go
+++ b/service/bitbucket/server_api_context.go
@@ -47,12 +47,20 @@ func withServerVariables(ctx context.Context, bbURL string) (context.Context, er
 		return ctx, fmt.Errorf("failed to parse Bitbucket Server URL: %w", err)
 	}
 
+	if parsed.Scheme == "" {
+		return ctx, fmt.Errorf("unable to determine scheme of Bitbucket Server URL: %w", err)
+	}
+
+	if parsed.Host == "" {
+		return ctx, fmt.Errorf("unable to determine host of Bitbucket Server URL: %w", err)
+	}
+
 	return context.WithValue(
 		ctx,
 		insights.ContextServerVariables,
 		map[string]string{
 			"protocol":        parsed.Scheme,
-			"bitbucketDomain": parsed.Host,
+			"bitbucketDomain": parsed.Host + parsed.Path,
 		},
 	), nil
 }

--- a/service/bitbucket/server_api_context_test.go
+++ b/service/bitbucket/server_api_context_test.go
@@ -1,0 +1,73 @@
+package bitbucket
+
+import (
+	"context"
+	"testing"
+
+	insights "github.com/reva2/bitbucket-insights-api"
+)
+
+func TestWithServerVariables(t *testing.T) {
+	serverTests := []struct {
+		url             string
+		protocol        string
+		bitbucketDomain string
+	}{
+		{"http://bitbucket.host.tld", "http", "bitbucket.host.tld"},
+		{"https://host.tld", "https", "host.tld"},
+		{"http://host.tld/bitbucket", "http", "host.tld/bitbucket"},
+		{"https://host.tld/bit/bu/cket", "https", "host.tld/bit/bu/cket"},
+		{"http://localhost:7990", "http", "localhost:7990"},
+		{"https://localhost:7990/bb", "https", "localhost:7990/bb"},
+	}
+
+	for _, server := range serverTests {
+		// given
+		ctx := context.Background()
+
+		t.Run(server.url, func(t *testing.T) {
+			// when
+			resCtx, err := withServerVariables(ctx, server.url)
+
+			// then
+			if err != nil {
+				t.Fatalf("valid url must not cause error")
+			}
+
+			serverVariables := resCtx.Value(insights.ContextServerVariables)
+			if serverVariables == nil {
+				t.Fatalf("serverVariables must not be nil")
+			}
+
+			actualProtocol := serverVariables.(map[string]string)["protocol"]
+			if actualProtocol != server.protocol {
+				t.Fatalf("want %s, but got %s", server.protocol, actualProtocol)
+			}
+
+			actualDomain := serverVariables.(map[string]string)["bitbucketDomain"]
+			if actualDomain != server.bitbucketDomain {
+				t.Fatalf("want %s, but got %s", server.bitbucketDomain, actualDomain)
+			}
+		})
+	}
+
+	wrongServerTests := []string{
+		":::",
+		"http//bitbucket.my-company.com",
+		"http::/bitbucket.my-company.com",
+	}
+
+	for _, server := range wrongServerTests {
+		// given
+		ctx := context.Background()
+
+		t.Run("fail to parse "+server, func(t *testing.T) {
+			// when
+			resCtx, err := withServerVariables(ctx, server)
+
+			if err == nil {
+				t.Fatalf("expect parsing to fail for url: %s, but got %s", server, resCtx.Value(insights.ContextServerVariables))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix the parsing of BITBUCKET_SERVER_URL with subpath #1124

- Fix the parsing by including the path into client configuration
- Add test cases for the parsing
- Fix typos in error messages
-  Distinguish between Bitbucket Cloud and Bitbucket Server for API errors

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
