### PR TITLE
GitHub Action for Prettier + Add link to actionlint action

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ You can use public GitHub Actions to start using reviewdog with ease! :tada: :ar
 
 - Common
   - [reviewdog/action-misspell](https://github.com/reviewdog/action-misspell) - Run [misspell](https://github.com/client9/misspell).
+  - [EPMatt/reviewdog-action-prettier](https://github.com/EPMatt/reviewdog-action-prettier) - Run [Prettier](https://prettier.io/).
 - Text (e.g. Markdown)
   - [reviewdog/action-alex](https://github.com/reviewdog/action-alex) - Run [alex](https://github.com/get-alex/alex) which catches insensitive, inconsiderate writing. (e.g. master/slave)
   - [reviewdog/action-languagetool](https://github.com/reviewdog/action-languagetool) - Run [languagetool](https://github.com/languagetool-org/languagetool).
@@ -669,6 +670,8 @@ You can use public GitHub Actions to start using reviewdog with ease! :tada: :ar
   - [dvdandroid/action-android-lint](https://github.com/DVDAndroid/action-android-lint) - Run [Android Lint](https://developer.android.com/studio/write/lint)
 - Ansible
   - [reviewdog/action-ansiblelint](https://github.com/reviewdog/action-ansiblelint) - Run [ansible-lint](https://github.com/ansible/ansible-lint)
+- GitHub Actions
+  - [reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint) - Run [actionlint](https://github.com/rhysd/actionlint)
   
 ... and more on [GitHub Marketplace](https://github.com/marketplace?utf8=✓&type=actions&query=reviewdog).
 


### PR DESCRIPTION
Hi there,

first of all I really want to spend some words to thank all the reviewdog contributors for maintaining such a useful code review tool to the dev community. Keep going! 🚀 

While looking at the available GitHub Actions for reviewdog I noticed no one was available for Prettier. Given the popularity and utility of such a widely used code formatter, I decided to build one and here we are. :)

The action is available [here](https://github.com/EPMatt/reviewdog-action-prettier). If you have any suggestion or improvement, I'd be happy to hear your opinion. :)

This PR just adds a link to the action's repository to the list of public reviewdog GitHub Actions, provided in the README file. Moreover, it also adds a link to the [reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint) action which I noticed was missing in the README.

Thank you!

- [X] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

