### PR TITLE
bump Go 1.19

### DIFF
--- a/.github/workflows/deploy-doghouse.yml
+++ b/.github/workflows/deploy-doghouse.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 50 # Need git history for testing.
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.15
+          go-version: '1.15'
       - run: go test -v -race  ./...
   deploy:
     permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: '1.19'
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,27 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '1.19'
-
     - uses: actions/checkout@v3
       with:
         fetch-depth: 50 # Need git history for testing.
 
-    # https://github.com/actions/cache/blob/master/examples.md#go---modules
-    - name: Cache Go Modules
-      id: cache
-      uses: actions/cache@v3
+    - uses: actions/setup-go@v3
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Download Go Modules
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: go mod download
+        go-version: '1.19'
+        cache: true
 
     - name: Test
       run: go test -v -race -coverpkg=./... -coverprofile=coverage.txt ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       # Setup Go for building reviewdog binary.
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: '1.19'
 
       # Test goreleaser if the tag is empty.
       - name: Test goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.19'
+          cache: true
 
       # Test goreleaser if the tag is empty.
       - name: Test goreleaser

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,11 +14,12 @@ jobs:
     name: reviewdog (github-check)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
           go-version: '1.x'
-
-      - uses: actions/checkout@v3
+          cache: true
 
       - name: Install linters
         run: go install golang.org/x/lint/golint@latest
@@ -56,25 +57,12 @@ jobs:
     name: reviewdog on Pull Request
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
           go-version: '1.x'
-
-      - uses: actions/checkout@v3
-
-      # https://github.com/actions/cache/blob/master/examples.md#go---modules
-      - name: Cache Go Modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Download Go Modules
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: go mod download
+          cache: true
 
       - name: Install linters
         run: go install golang.org/x/lint/golint@latest
@@ -204,6 +192,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.x'
+          cache: true
       - uses: reviewdog/action-staticcheck@v1
         with:
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: '1.x'
 
       - uses: actions/checkout@v3
 
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: '1.x'
 
       - uses: actions/checkout@v3
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/reviewdog/reviewdog
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go v0.102.1 // indirect
+	cloud.google.com/go/compute v1.9.0
 	cloud.google.com/go/datastore v1.8.0
 	cloud.google.com/go/monitoring v1.4.0 // indirect
 	cloud.google.com/go/trace v1.2.0 // indirect
@@ -31,8 +32,6 @@ require (
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-require cloud.google.com/go/compute v1.9.0
 
 require (
 	github.com/aws/aws-sdk-go v1.43.31 // indirect


### PR DESCRIPTION
Go 1.19 has been released.

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

