### PR TITLE
fix deprecated configure of goreleaser

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -9,7 +9,7 @@ release:
   github:
     owner: reviewdog
     name: nightly
-  # Do not set prelease so that https://github.com/reviewdog/nightly/releases/latest always points to the latest version.
+  # Do not set prerelease so that https://github.com/reviewdog/nightly/releases/latest always points to the latest version.
   prerelease: false
 
 builds:
@@ -29,15 +29,20 @@ builds:
  
 archives:
   - id: main
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- with .Arm }}v{{ . }}{{ end }}
+      {{- with .Mips }}_{{ . }}{{ end }}
+      {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     files:
       - LICENSE
       - README.md
+    rlcp: true
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm
       - arm64
- 
+
 archives:
   - id: main
     name_template: >-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,15 +21,20 @@ builds:
  
 archives:
   - id: main
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- with .Arm }}v{{ . }}{{ end }}
+      {{- with .Mips }}_{{ . }}{{ end }}
+      {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     files:
       - LICENSE
       - README.md
+    rlcp: true
 
 brews:
   - tap:


### PR DESCRIPTION
fix DEPRECATED warnings of goreleaser. 

```
Run goreleaser/goreleaser-action@v4
Downloading https://github.com/goreleaser/goreleaser/releases/download/v1.14.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/9b1579dd-7d1f-4706-b6b1-b183dc0e8cb3 -f /home/runner/work/_temp/7d60f6ed-4281-4a1c-a0c6-03cd59e6d085
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/1.14.0/x64/goreleaser check
  • loading config file                              file=.goreleaser.yml
  • checking config...
    • DEPRECATED: `archives.rlcp` will be the default soon, check https://goreleaser.com/deprecations#archivesrlcp for more info
    • DEPRECATED: `archives.replacements` should not be used anymore, check https://goreleaser.com/deprecations#archivesreplacements for more info
  ⨯ command failed                                   error=config is valid, but uses deprecated properties, check logs above for details
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.14.0/x64/goreleaser' failed with exit code 2
```

The log of `goreleaser release --snapshot --rm-dist` is here:

```
% goreleaser release --snapshot --rm-dist
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=2c9939c287e19d12fbb6195d286ea654f3479fc8 latest tag=v0.14.1
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
  • snapshotting
    • building snapshot...                           version=v0.14.1-next
  • checking distribution directory
    • --rm-dist is set, cleaning it up
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/reviewdog_windows_arm64/reviewdog.exe
    • building                                       binary=dist/reviewdog_windows_386/reviewdog.exe
    • building                                       binary=dist/reviewdog_darwin_amd64_v1/reviewdog
    • building                                       binary=dist/reviewdog_linux_386/reviewdog
    • building                                       binary=dist/reviewdog_linux_amd64_v1/reviewdog
    • building                                       binary=dist/reviewdog_windows_arm_6/reviewdog.exe
    • building                                       binary=dist/reviewdog_windows_amd64_v1/reviewdog.exe
    • building                                       binary=dist/reviewdog_darwin_arm64/reviewdog
    • building                                       binary=dist/reviewdog_linux_arm_6/reviewdog
    • building                                       binary=dist/reviewdog_linux_arm64/reviewdog
    • took: 1s
  • archives
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Windows_x86_64.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Linux_x86_64.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Darwin_arm64.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Linux_arm64.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Linux_armv6.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Windows_arm64.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Windows_i386.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Windows_armv6.tar.gz
    • creating                                       archive=dist/reviewdog_v0.14.1-next_Linux_i386.tar.gz
    • took: 2s
  • calculating checksums
  • homebrew tap formula
    • guessing install to be "bin.install \"reviewdog\""
    • guessing install to be "bin.install \"reviewdog\""
    • guessing install to be "bin.install \"reviewdog\""
    • guessing install to be "bin.install \"reviewdog\""
    • guessing install to be "bin.install \"reviewdog\""
    • writing                                        formula=dist/reviewdog.rb
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 3s
```

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

