### PR TITLE
Fix a typo

### DIFF
--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -41,7 +41,7 @@ type CheckRequest struct {
 	//
 	// OutsideDiff represents whether it report results in outside diff or not as
 	// annotations. It's useful only when PullRequest != 0. If PullRequest is
-	// empty, it will always report results all resutls including outside diff
+	// empty, it will always report results all results including outside diff
 	// (because there are no diff!).
 	// Optional.
 	OutsideDiff bool `json:"outside_diff"`


### PR DESCRIPTION
This PR is fix a typo.
- resutls -> results


- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

