### PR TITLE
Refactor tests to use t.Setenv instead of os.Setenv

### DIFF
--- a/cienv/cienv_test.go
+++ b/cienv/cienv_test.go
@@ -6,55 +6,8 @@ import (
 	"testing"
 )
 
-func setupEnvs() (cleanup func()) {
-	var cleanEnvs = []string{
-		"CIRCLE_BRANCH",
-		"CIRCLE_PROJECT_REPONAME",
-		"CIRCLE_PROJECT_USERNAME",
-		"CIRCLE_PR_NUMBER",
-		"CIRCLE_PULL_REQUEST",
-		"CIRCLE_SHA1",
-		"CI_BRANCH",
-		"CI_COMMIT",
-		"CI_COMMIT_SHA",
-		"CI_PROJECT_NAME",
-		"CI_PROJECT_NAMESPACE",
-		"CI_PULL_REQUEST",
-		"CI_REPO_NAME",
-		"CI_REPO_OWNER",
-		"DRONE_COMMIT",
-		"DRONE_COMMIT_BRANCH",
-		"DRONE_PULL_REQUEST",
-		"DRONE_REPO",
-		"DRONE_REPO_NAME",
-		"DRONE_REPO_OWNER",
-		"TRAVIS_COMMIT",
-		"TRAVIS_PULL_REQUEST",
-		"TRAVIS_PULL_REQUEST_BRANCH",
-		"TRAVIS_PULL_REQUEST_SHA",
-		"TRAVIS_REPO_SLUG",
-		"GITHUB_ACTIONS",
-		"GERRIT_CHANGE_ID",
-		"GERRIT_REVISION_ID",
-		"GERRIT_BRANCH",
-	}
-	saveEnvs := make(map[string]string)
-	for _, key := range cleanEnvs {
-		saveEnvs[key] = os.Getenv(key)
-		os.Unsetenv(key)
-	}
-	return func() {
-		for key, value := range saveEnvs {
-			os.Setenv(key, value)
-		}
-	}
-}
-
 func TestGetBuildInfo_travis(t *testing.T) {
-	cleanup := setupEnvs()
-	defer cleanup()
-
-	os.Setenv("TRAVIS_REPO_SLUG", "invalid repo slug")
+	t.Setenv("TRAVIS_REPO_SLUG", "invalid repo slug")
 
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
@@ -62,7 +15,7 @@ func TestGetBuildInfo_travis(t *testing.T) {
 		t.Log(err)
 	}
 
-	os.Setenv("TRAVIS_REPO_SLUG", "haya14busa/reviewdog")
+	t.Setenv("TRAVIS_REPO_SLUG", "haya14busa/reviewdog")
 
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
@@ -70,7 +23,7 @@ func TestGetBuildInfo_travis(t *testing.T) {
 		t.Log(err)
 	}
 
-	os.Setenv("TRAVIS_PULL_REQUEST_SHA", "sha")
+	t.Setenv("TRAVIS_PULL_REQUEST_SHA", "sha")
 
 	_, isPR, err := GetBuildInfo()
 	if err != nil {
@@ -80,7 +33,7 @@ func TestGetBuildInfo_travis(t *testing.T) {
 		t.Errorf("isPR = %v, want false", isPR)
 	}
 
-	os.Setenv("TRAVIS_PULL_REQUEST", "str")
+	t.Setenv("TRAVIS_PULL_REQUEST", "str")
 
 	_, isPR, err = GetBuildInfo()
 	if err != nil {
@@ -90,7 +43,7 @@ func TestGetBuildInfo_travis(t *testing.T) {
 		t.Errorf("isPR = %v, want false", isPR)
 	}
 
-	os.Setenv("TRAVIS_PULL_REQUEST", "1")
+	t.Setenv("TRAVIS_PULL_REQUEST", "1")
 
 	if _, isPR, err = GetBuildInfo(); err != nil {
 		t.Errorf("got unexpected err: %v", err)
@@ -99,7 +52,7 @@ func TestGetBuildInfo_travis(t *testing.T) {
 		t.Error("should be pull request build")
 	}
 
-	os.Setenv("TRAVIS_PULL_REQUEST", "false")
+	t.Setenv("TRAVIS_PULL_REQUEST", "false")
 
 	_, isPR, err = GetBuildInfo()
 	if err != nil {
@@ -111,35 +64,32 @@ func TestGetBuildInfo_travis(t *testing.T) {
 }
 
 func TestGetBuildInfo_circleci(t *testing.T) {
-	cleanup := setupEnvs()
-	defer cleanup()
-
 	if _, isPR, err := GetBuildInfo(); isPR {
 		t.Errorf("should be non pull-request build. error: %v", err)
 	}
 
-	os.Setenv("CIRCLE_PR_NUMBER", "1")
+	t.Setenv("CIRCLE_PR_NUMBER", "1")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("CIRCLE_PROJECT_USERNAME", "haya14busa")
+	t.Setenv("CIRCLE_PROJECT_USERNAME", "haya14busa")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("CIRCLE_PROJECT_REPONAME", "reviewdog")
+	t.Setenv("CIRCLE_PROJECT_REPONAME", "reviewdog")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("CIRCLE_SHA1", "sha1")
+	t.Setenv("CIRCLE_SHA1", "sha1")
 	g, isPR, err := GetBuildInfo()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -159,14 +109,11 @@ func TestGetBuildInfo_circleci(t *testing.T) {
 }
 
 func TestGetBuildInfo_droneio(t *testing.T) {
-	cleanup := setupEnvs()
-	defer cleanup()
-
 	if _, isPR, err := GetBuildInfo(); isPR {
 		t.Errorf("should be non pull-request build. error: %v", err)
 	}
 
-	os.Setenv("DRONE_PULL_REQUEST", "1")
+	t.Setenv("DRONE_PULL_REQUEST", "1")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
@@ -174,7 +121,7 @@ func TestGetBuildInfo_droneio(t *testing.T) {
 	}
 
 	// Drone <= 0.4 without valid repo
-	os.Setenv("DRONE_REPO", "invalid")
+	t.Setenv("DRONE_REPO", "invalid")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
@@ -183,7 +130,7 @@ func TestGetBuildInfo_droneio(t *testing.T) {
 	os.Unsetenv("DRONE_REPO")
 
 	// Drone > 0.4 without DRONE_REPO_NAME
-	os.Setenv("DRONE_REPO_OWNER", "haya14busa")
+	t.Setenv("DRONE_REPO_OWNER", "haya14busa")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
@@ -192,7 +139,7 @@ func TestGetBuildInfo_droneio(t *testing.T) {
 	os.Unsetenv("DRONE_REPO_OWNER")
 
 	// Drone > 0.4 without DRONE_REPO_OWNER
-	os.Setenv("DRONE_REPO_NAME", "reviewdog")
+	t.Setenv("DRONE_REPO_NAME", "reviewdog")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
@@ -200,10 +147,10 @@ func TestGetBuildInfo_droneio(t *testing.T) {
 	}
 
 	// Drone > 0.4 have valid variables
-	os.Setenv("DRONE_REPO_NAME", "reviewdog")
-	os.Setenv("DRONE_REPO_OWNER", "haya14busa")
+	t.Setenv("DRONE_REPO_NAME", "reviewdog")
+	t.Setenv("DRONE_REPO_OWNER", "haya14busa")
 
-	os.Setenv("DRONE_COMMIT", "sha1")
+	t.Setenv("DRONE_COMMIT", "sha1")
 	g, isPR, err := GetBuildInfo()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -223,35 +170,32 @@ func TestGetBuildInfo_droneio(t *testing.T) {
 }
 
 func TestGetBuildInfo_common(t *testing.T) {
-	cleanup := setupEnvs()
-	defer cleanup()
-
 	if _, isPR, err := GetBuildInfo(); isPR {
 		t.Errorf("should be non pull-request build. error: %v", err)
 	}
 
-	os.Setenv("CI_PULL_REQUEST", "1")
+	t.Setenv("CI_PULL_REQUEST", "1")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("CI_REPO_OWNER", "haya14busa")
+	t.Setenv("CI_REPO_OWNER", "haya14busa")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("CI_REPO_NAME", "reviewdog")
+	t.Setenv("CI_REPO_NAME", "reviewdog")
 	if _, _, err := GetBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("CI_COMMIT", "sha1")
+	t.Setenv("CI_COMMIT", "sha1")
 	g, isPR, err := GetBuildInfo()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -271,9 +215,6 @@ func TestGetBuildInfo_common(t *testing.T) {
 }
 
 func TestGetGerritBuildInfo(t *testing.T) {
-	cleanup := setupEnvs()
-	defer cleanup()
-
 	// without any environment variables
 	if _, err := GetGerritBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
@@ -281,21 +222,21 @@ func TestGetGerritBuildInfo(t *testing.T) {
 		t.Log(err)
 	}
 
-	os.Setenv("GERRIT_CHANGE_ID", "changedID1")
+	t.Setenv("GERRIT_CHANGE_ID", "changedID1")
 	if _, err := GetGerritBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("GERRIT_REVISION_ID", "revisionID1")
+	t.Setenv("GERRIT_REVISION_ID", "revisionID1")
 	if _, err := GetGerritBuildInfo(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
 
-	os.Setenv("GERRIT_BRANCH", "master")
+	t.Setenv("GERRIT_BRANCH", "master")
 	if _, err := GetGerritBuildInfo(); err != nil {
 		t.Error("nil expected but got err")
 	}

--- a/project/run_test.go
+++ b/project/run_test.go
@@ -296,10 +296,7 @@ func TestFilteredEnviron(t *testing.T) {
 	}
 
 	for _, name := range names {
-		defer func(name, value string) {
-			os.Setenv(name, value)
-		}(name, os.Getenv(name))
-		os.Setenv(name, "value")
+		t.Setenv(name, "value")
 	}
 
 	filtered := filteredEnviron()

--- a/service/github/github_test.go
+++ b/service/github/github_test.go
@@ -34,22 +34,6 @@ func setupGitHubClient() *github.Client {
 	return github.NewClient(tc)
 }
 
-func setupEnvs() (cleanup func()) {
-	var cleanEnvs = []string{
-		"GITHUB_ACTIONS",
-	}
-	saveEnvs := make(map[string]string)
-	for _, key := range cleanEnvs {
-		saveEnvs[key] = os.Getenv(key)
-		os.Unsetenv(key)
-	}
-	return func() {
-		for key, value := range saveEnvs {
-			os.Setenv(key, value)
-		}
-	}
-}
-
 func moveToRootDir() {
 	os.Chdir("../..")
 }
@@ -107,12 +91,12 @@ index b380b67..6abc0f1 100644
 @@ -4,6 +4,9 @@ import (
  	"os/exec"
  )
- 
+
 +func TestNewExportedFunc() {
 +}
 +
  var _ DiffService = &DiffString{}
- 
+
  type DiffString struct {
 diff --git a/reviewdog.go b/reviewdog.go
 index 61450f3..f63f149 100644
@@ -121,7 +105,7 @@ index 61450f3..f63f149 100644
 @@ -10,18 +10,18 @@ import (
  	"github.com/reviewdog/reviewdog/diff"
  )
- 
+
 +var TestExportedVarWithoutComment = 1
 +
 +func NewReviewdog(p Parser, c CommentService, d DiffService) *Reviewdog {
@@ -133,7 +117,7 @@ index 61450f3..f63f149 100644
  	c CommentService
  	d DiffService
  }
- 
+
 -func NewReviewdog(p Parser, c CommentService, d DiffService) *Reviewdog {
 -	return &Reviewdog{p: p, c: c, d: d}
 -}
@@ -197,7 +181,6 @@ func TestGitHubPullRequest_Post_Flush_review_api(t *testing.T) {
 	cwd, _ := os.Getwd()
 	defer os.Chdir(cwd)
 	moveToRootDir()
-	defer setupEnvs()()
 
 	listCommentsAPICalled := 0
 	postCommentsAPICalled := 0
@@ -1098,7 +1081,6 @@ func TestGitHubPullRequest_Post_toomany(t *testing.T) {
 	cwd, _ := os.Getwd()
 	defer os.Chdir(cwd)
 	moveToRootDir()
-	defer setupEnvs()()
 
 	listCommentsAPICalled := 0
 	postCommentsAPICalled := 0
@@ -1167,7 +1149,6 @@ func TestGitHubPullRequest_workdir(t *testing.T) {
 	cwd, _ := os.Getwd()
 	defer os.Chdir(cwd)
 	moveToRootDir()
-	defer setupEnvs()()
 
 	g, err := NewGitHubPullRequest(nil, "", "", 0, "")
 	if err != nil {


### PR DESCRIPTION
This PR simplifies testing code by using `T.Setenv`. From the [doc](https://pkg.go.dev/testing#T.Setenv):
```
Setenv calls os.Setenv(key, value) and uses Cleanup to restore the environment variable to its original value after the test.
```

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.