### PR TITLE
fix: Remove default error level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :bug: Fixes
 - [#967](https://github.com/reviewdog/reviewdog/pull/967) Fix parsing long lines in diffs #967
+- [#1426](https://github.com/reviewdog/reviewdog/pull/1426) Remove default error level
 - ...
 
 ### :rotating_light: Breaking changes

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -198,7 +198,7 @@ func init() {
 	flag.StringVar(&opt.conf, "conf", "", confDoc)
 	flag.StringVar(&opt.runners, "runners", "", runnersDoc)
 	flag.StringVar(&opt.reporter, "reporter", "local", reporterDoc)
-	flag.StringVar(&opt.level, "level", "error", levelDoc)
+	flag.StringVar(&opt.level, "level", "", levelDoc)
 	flag.BoolVar(&opt.guessPullRequest, "guess", false, guessPullRequestDoc)
 	flag.BoolVar(&opt.tee, "tee", false, teeDoc)
 	flag.Var(&opt.filterMode, "filter-mode", filterModeDoc)


### PR DESCRIPTION
Since https://github.com/reviewdog/reviewdog/pull/1170 we can dynamically calculate the check conclusion from annotations if a level config isn't provided. However, reviewdog currently defaults level to error, which prevents the dynamic calculation from ever running.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

note: staticcheck/textlint errors are unrelated to changes and occur for other PRs as well (e.g. https://github.com/reviewdog/reviewdog/pull/1425)

todo: I'm going to set up a public test repo to verify that this works as expected

