### PR TITLE
feat: add ghe path link support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :rocket: Enhancements
 - [#1170](https://github.com/reviewdog/reviewdog/pull/1170) Calculate check conclusion from annotations
+- [#1433](https://github.com/reviewdog/reviewdog/pull/1433) Add path link support for GitHub Enterprise
 - ...
 
 ### :bug: Fixes

--- a/service/github/githubutils/utils_test.go
+++ b/service/github/githubutils/utils_test.go
@@ -1,6 +1,7 @@
 package githubutils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/reviewdog/reviewdog/proto/rdf"
@@ -10,6 +11,7 @@ func TestLinkedMarkdownDiagnostic(t *testing.T) {
 	tests := []struct {
 		owner, repo, sha string
 		d                *rdf.Diagnostic
+		serverUrl	     string
 		want             string
 	}{
 		{
@@ -26,7 +28,8 @@ func TestLinkedMarkdownDiagnostic(t *testing.T) {
 				},
 				Message: "msg",
 			},
-			want: "[path/to/file.txt|1414 col 14|](http://github.com/o/r/blob/s/path/to/file.txt#L1414) msg",
+			serverUrl: "",
+			want: "[path/to/file.txt|1414 col 14|](https://github.com/o/r/blob/s/path/to/file.txt#L1414) msg",
 		},
 		{
 			owner: "o",
@@ -42,7 +45,8 @@ func TestLinkedMarkdownDiagnostic(t *testing.T) {
 				},
 				Message: "msg",
 			},
-			want: "[path/to/file.txt|1414|](http://github.com/o/r/blob/s/path/to/file.txt#L1414) msg",
+			serverUrl: "",
+			want: "[path/to/file.txt|1414|](https://github.com/o/r/blob/s/path/to/file.txt#L1414) msg",
 		},
 		{
 			owner: "o",
@@ -54,10 +58,32 @@ func TestLinkedMarkdownDiagnostic(t *testing.T) {
 				},
 				Message: "msg",
 			},
-			want: "[path/to/file.txt||](http://github.com/o/r/blob/s/path/to/file.txt) msg",
+			serverUrl: "",
+			want: "[path/to/file.txt||](https://github.com/o/r/blob/s/path/to/file.txt) msg",
+		},
+		{
+			owner: "o",
+			repo:  "r",
+			sha:   "s",
+			d: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path: "path/to/file.txt",
+				},
+				Message: "msg",
+			},
+			serverUrl: "https://xpto.com",
+			want: "[path/to/file.txt||](https://xpto.com/o/r/blob/s/path/to/file.txt) msg",
 		},
 	}
 	for _, tt := range tests {
+		if errUnset := os.Unsetenv("GITHUB_SERVER_URL"); errUnset != nil {
+			t.Error(errUnset)
+		}
+		if tt.serverUrl != "" {
+			if errSet := os.Setenv("GITHUB_SERVER_URL", tt.serverUrl); errSet != nil {
+				t.Error(errSet)
+			}
+		}
 		if got := LinkedMarkdownDiagnostic(tt.owner, tt.repo, tt.sha, tt.d); got != tt.want {
 			t.Errorf("LinkedMarkdownDiagnostic(%q, %q, %q, %#v) = %q, want %q",
 				tt.owner, tt.repo, tt.sha, tt.d, got, tt.want)


### PR DESCRIPTION
This PR adds support for a custom github server url via environment variable GITHUB_SERVER_URL. This variable is populated by default in GitHub actions with the current GitHub URL. With this approach we benefit from path link support on self hosted instances of GitHub (GitHub Enterprise), that currently is broken and pointing to `github.com`.

Tell me If you need me to update something. Thanks for the awesome project 💪 

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

