### PR TITLE
fix: support determining build info on more GitHub Actions events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :rocket: Enhancements
 - [#1170](https://github.com/reviewdog/reviewdog/pull/1170) Calculate check conclusion from annotations
 - [#1433](https://github.com/reviewdog/reviewdog/pull/1433) Add path link support for GitHub Enterprise
+- [#1447](https://github.com/reviewdog/reviewdog/pull/1447) Support determining build info on more GitHub Actions events
 - ...
 
 ### :bug: Fixes

--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -95,6 +95,9 @@ func getBuildInfoFromGitHubActionEventPath(eventPath string) (*BuildInfo, bool, 
 	if info.SHA == "" {
 		info.SHA = event.HeadCommit.ID
 	}
+	if info.SHA == "" {
+		info.SHA = os.Getenv("GITHUB_SHA")
+	}
 	return info, info.PullRequest != 0, nil
 }
 


### PR DESCRIPTION
There are several GitHub Actions events that don't include a commit SHA in the event payload fields that are currently parsed by Reviewdog. For example, the [`release` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) only includes a `target_commitish` field that does not contain a commit hash. This renders Reviewdog less suitable for use in workflows triggered by such events.

To improve on the situation, let Reviewdog parse the `GITHUB_SHA` environment variable to fetch a commit SHA if the already available methods fail. [As explained in the GitHub docs](https://docs.github.com/en/actions/learn-github-actions/variables), this environment variable is a useful last resort for other event types.


- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.