### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -14,7 +14,7 @@ release:
 
 builds:
   - env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     main: ./cmd/reviewdog/
     ldflags: -s -w -X github.com/reviewdog/reviewdog/commands.Version={{.Version}}
     goos:
@@ -26,7 +26,7 @@ builds:
       - amd64
       - arm
       - arm64
- 
+
 archives:
   - id: main
     name_template: >-
@@ -42,10 +42,9 @@ archives:
     files:
       - LICENSE
       - README.md
-    rlcp: true
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ before:
 
 builds:
   - env:
-    - CGO_ENABLED=0
+      - CGO_ENABLED=0
     main: ./cmd/reviewdog/
     ldflags: -s -w -X github.com/reviewdog/reviewdog/commands.Version={{.Version}}
     goos:
@@ -34,20 +34,19 @@ archives:
     files:
       - LICENSE
       - README.md
-    rlcp: true
 
 brews:
   - tap:
       owner: reviewdog
       name: homebrew-tap
     folder: Formula
-    homepage:  https://github.com/reviewdog/reviewdog
+    homepage: https://github.com/reviewdog/reviewdog
     description: Automated code review tool integrated with any code analysis tools regardless of programming language.
     test: |
       system "#{bin}/reviewdog -version"
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .Tag }}-next"
@@ -56,6 +55,6 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
-    - '^chore'
+      - "^docs:"
+      - "^test:"
+      - "^chore"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ archives:
       - README.md
 
 brews:
-  - tap:
+  - repository:
       owner: reviewdog
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
some properties of `.goreleaser.yml` are now deprecated, and `goreleaser check` fails:

https://github.com/reviewdog/reviewdog/actions/runs/5598907307/jobs/10239188000

```
  • loading config file                              file=.goreleaser.yml
  • checking config...
    • DEPRECATED: `archives.rlcp` should not be used anymore, check https://goreleaser.com/deprecations#archivesrlcp for more info
    • DEPRECATED: `brews.tap` should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  •                                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

I fixed deprecated configures.

> https://goreleaser.com/deprecations/#archivesrlcp
>
> archives.rlcp
>
> This option is now default and can't be changed. You can remove it from your configuration files.

> https://goreleaser.com/deprecations/#brewstap
>
> brews.tap
>
> Replace tap with repository.


The version of goreleaser is 1.19.2.

```
$ goreleaser -v
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.19.2
GitCommit:     b95fd394866efeb147769b49a469f88186606177
GitTreeState:  dirty
BuildDate:     2023-07-07T13:32:08
BuiltBy:       homebrew
GoVersion:     go1.20.5
Compiler:      gc
ModuleSum:     unknown
Platform:      darwin/arm64
```