### PR TITLE
Initializes the Golang environment for the CodeQL tools.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # Initializes the Golang environment for the CodeQL tools.
+    # https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
`go.mod` requires Go 1.21, but the GitHub Actions runner image still uses Go 1.20 by default.

https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087


- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

