### PR TITLE
Use CI_MERGE_REQUEST_DIFF_BASE_SHA Gitlab envvar if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :rocket: Enhancements
 - [#1573](https://github.com/reviewdog/reviewdog/pull/1573) Add filter tests for file/nofilter mode
 - [#1576](https://github.com/reviewdog/reviewdog/pull/1576) Support `--filter-mode=file` in `github-pr-review`
+- [#1596](https://github.com/reviewdog/reviewdog/pull/1596) Use `CI_MERGE_REQUEST_DIFF_BASE_SHA` envvar if available in `gitlab-mr-discussion`
 
 ### :bug: Fixes
 - ...


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Why is this change useful?
1. It saves some unnecessary Gitlab API calls if that specific envvar is available ([which should be the case since Gitlab 13.7](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html))
2. It allows overriding the base commit sha from an environment variable which I used as a workaround for https://github.com/reviewdog/reviewdog/issues/1150. (I store the sha of the last successfully scanned commit in a file and persist it in the Gitlab CI cache between consecutive job runs. By providing this last scanned SHA as the base commit (`CI_MERGE_REQUEST_DIFF_BASE_SHA` envvar) when running reviewdog, it will only comment for lines which were changed since the last run and will not create multiple comments for issues already existing.