### PR TITLE
migrate deprecated gitlab functions

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -639,8 +639,8 @@ func bitbucketBuildWithClient(ctx context.Context) (*cienv.BuildInfo, bbservice.
 func fetchMergeRequestIDFromCommit(cli *gitlab.Client, projectID, sha string) (id int, err error) {
 	// https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests
 	opt := &gitlab.ListProjectMergeRequestsOptions{
-		State:   gitlab.String("opened"),
-		OrderBy: gitlab.String("updated_at"),
+		State:   gitlab.Ptr("opened"),
+		OrderBy: gitlab.Ptr("updated_at"),
 	}
 	mrs, _, err := cli.MergeRequests.ListProjectMergeRequests(projectID, opt)
 	if err != nil {

--- a/service/gitlab/gitlab_mr_commit.go
+++ b/service/gitlab/gitlab_mr_commit.go
@@ -94,10 +94,10 @@ func (g *MergeRequestCommitCommenter) postCommentsForEach(ctx context.Context) e
 				commitID = g.sha
 			}
 			prcomment := &gitlab.PostCommitCommentOptions{
-				Note:     gitlab.String(body),
-				Path:     gitlab.String(loc.GetPath()),
-				Line:     gitlab.Int(lnum),
-				LineType: gitlab.String("new"),
+				Note:     gitlab.Ptr(body),
+				Path:     gitlab.Ptr(loc.GetPath()),
+				Line:     gitlab.Ptr(lnum),
+				LineType: gitlab.Ptr("new"),
 			}
 			_, _, err = g.cli.Commits.PostCommitComment(g.projects, commitID, prcomment, gitlab.WithContext(ctx))
 			return err

--- a/service/gitlab/gitlab_mr_discussion.go
+++ b/service/gitlab/gitlab_mr_discussion.go
@@ -123,19 +123,19 @@ func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Contex
 		}
 		eg.Go(func() error {
 			pos := &gitlab.PositionOptions{
-				StartSHA:     gitlab.String(targetBranch.Commit.ID),
-				HeadSHA:      gitlab.String(g.sha),
-				BaseSHA:      gitlab.String(targetBranch.Commit.ID),
-				PositionType: gitlab.String("text"),
-				NewPath:      gitlab.String(loc.GetPath()),
-				NewLine:      gitlab.Int(lnum),
+				StartSHA:     gitlab.Ptr(targetBranch.Commit.ID),
+				HeadSHA:      gitlab.Ptr(g.sha),
+				BaseSHA:      gitlab.Ptr(targetBranch.Commit.ID),
+				PositionType: gitlab.Ptr("text"),
+				NewPath:      gitlab.Ptr(loc.GetPath()),
+				NewLine:      gitlab.Ptr(lnum),
 			}
 			if c.Result.OldPath != "" && c.Result.OldLine != 0 {
-				pos.OldPath = gitlab.String(c.Result.OldPath)
-				pos.OldLine = gitlab.Int(c.Result.OldLine)
+				pos.OldPath = gitlab.Ptr(c.Result.OldPath)
+				pos.OldLine = gitlab.Ptr(c.Result.OldLine)
 			}
 			discussion := &gitlab.CreateMergeRequestDiscussionOptions{
-				Body:     gitlab.String(body),
+				Body:     gitlab.Ptr(body),
 				Position: pos,
 			}
 			_, _, err := g.cli.Discussions.CreateMergeRequestDiscussion(g.projects, g.pr, discussion)

--- a/service/gitlab/gitlab_mr_discussion_test.go
+++ b/service/gitlab/gitlab_mr_discussion_test.go
@@ -220,14 +220,14 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			switch *got.Position.NewPath {
 			case "file.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.String(commentutil.MarkdownComment(newComment1)),
+					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment1)),
 					Position: &gitlab.PositionOptions{
-						BaseSHA:      gitlab.String("xxx"),
-						StartSHA:     gitlab.String("xxx"),
-						HeadSHA:      gitlab.String("sha"),
-						PositionType: gitlab.String("text"),
-						NewPath:      gitlab.String("file.go"),
-						NewLine:      gitlab.Int(14),
+						BaseSHA:      gitlab.Ptr("xxx"),
+						StartSHA:     gitlab.Ptr("xxx"),
+						HeadSHA:      gitlab.Ptr("sha"),
+						PositionType: gitlab.Ptr("text"),
+						NewPath:      gitlab.Ptr("file.go"),
+						NewLine:      gitlab.Ptr(14),
 					},
 				}
 				if diff := cmp.Diff(got, want); diff != "" {
@@ -235,14 +235,14 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				}
 			case "file2.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.String(commentutil.MarkdownComment(newComment2)),
+					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment2)),
 					Position: &gitlab.PositionOptions{
-						BaseSHA:      gitlab.String("xxx"),
-						StartSHA:     gitlab.String("xxx"),
-						HeadSHA:      gitlab.String("sha"),
-						PositionType: gitlab.String("text"),
-						NewPath:      gitlab.String("file2.go"),
-						NewLine:      gitlab.Int(15),
+						BaseSHA:      gitlab.Ptr("xxx"),
+						StartSHA:     gitlab.Ptr("xxx"),
+						HeadSHA:      gitlab.Ptr("sha"),
+						PositionType: gitlab.Ptr("text"),
+						NewPath:      gitlab.Ptr("file2.go"),
+						NewLine:      gitlab.Ptr(15),
 					},
 				}
 				if diff := cmp.Diff(got, want); diff != "" {
@@ -250,16 +250,16 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				}
 			case "new_file.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.String(commentutil.MarkdownComment(newComment3)),
+					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment3)),
 					Position: &gitlab.PositionOptions{
-						BaseSHA:      gitlab.String("xxx"),
-						StartSHA:     gitlab.String("xxx"),
-						HeadSHA:      gitlab.String("sha"),
-						PositionType: gitlab.String("text"),
-						NewPath:      gitlab.String("new_file.go"),
-						NewLine:      gitlab.Int(14),
-						OldPath:      gitlab.String("old_file.go"),
-						OldLine:      gitlab.Int(7),
+						BaseSHA:      gitlab.Ptr("xxx"),
+						StartSHA:     gitlab.Ptr("xxx"),
+						HeadSHA:      gitlab.Ptr("sha"),
+						PositionType: gitlab.Ptr("text"),
+						NewPath:      gitlab.Ptr("new_file.go"),
+						NewLine:      gitlab.Ptr(14),
+						OldPath:      gitlab.Ptr("old_file.go"),
+						OldLine:      gitlab.Ptr(7),
 					},
 				}
 				if diff := cmp.Diff(got, want); diff != "" {
@@ -270,14 +270,14 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				bodyExpected := commentutil.MarkdownComment(newCommentWithSuggestion) + "\n\n" + suggestions
 
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.String(bodyExpected),
+					Body: gitlab.Ptr(bodyExpected),
 					Position: &gitlab.PositionOptions{
-						BaseSHA:      gitlab.String("xxx"),
-						StartSHA:     gitlab.String("xxx"),
-						HeadSHA:      gitlab.String("sha"),
-						PositionType: gitlab.String("text"),
-						NewPath:      gitlab.String("file3.go"),
-						NewLine:      gitlab.Int(14),
+						BaseSHA:      gitlab.Ptr("xxx"),
+						StartSHA:     gitlab.Ptr("xxx"),
+						HeadSHA:      gitlab.Ptr("sha"),
+						PositionType: gitlab.Ptr("text"),
+						NewPath:      gitlab.Ptr("file3.go"),
+						NewLine:      gitlab.Ptr(14),
 					},
 				}
 				if diff := cmp.Diff(got, want); diff != "" {


### PR DESCRIPTION
[gitlab.Int](https://pkg.go.dev/github.com/xanzy/go-gitlab@v0.94.0#Int) and [gitlab.String](https://pkg.go.dev/github.com/xanzy/go-gitlab@v0.94.0#String) are now deprecated.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

