### PR TITLE
Explicit annotation reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- ...
+- [#1623](https://github.com/reviewdog/reviewdog/pull/1623) Add reporter for GitHub PR annotations `github-pr-annotations`
 
 ### :bug: Fixes
 - ...

--- a/README.md
+++ b/README.md
@@ -492,6 +492,18 @@ $ export REVIEWDOG_INSECURE_SKIP_VERIFY=true # set this as you need to skip veri
 See [GitHub Actions](#github-actions) section too if you can use GitHub
 Actions. You can also use public reviewdog GitHub Actions.
 
+### Reporter: GitHub PR Annotations (-reporter=github-pr-annotations)
+
+github-pr-annotations uses the GitHub Actions annotation format to output errors
+and warnings to `stdout` e.g.
+
+```
+::error line=11,col=41,file=app/index.md::[vale] reported by reviewdog 🐶%0A[demo.Spelling] Did you really mean 'boobarbaz'?%0A%0ARaw Output:%0A{"message": "[demo.Spelling] Did you really mean 'boobarbaz'?", "location": {"path": "app/index.md", "range": {"start": {"line": 11, "column": 41}}}, "severity": "ERROR"}
+```
+
+This reporter requires a valid GitHub API token to generate a diff, but will not
+use the token to report errors.
+
 ### Reporter: GitLab MergeRequest discussions (-reporter=gitlab-mr-discussion)
 
 [![gitlab-mr-discussion sample](https://user-images.githubusercontent.com/3797062/41810718-f91bc540-773d-11e8-8598-fbc09ce9b1c7.png)](https://gitlab.com/reviewdog/reviewdog/-/merge_requests/113#note_83411103)
@@ -929,6 +941,7 @@ so reviewdog will use [Check annotation](https://docs.github.com/en/rest/checks/
 | **`github-check`**           | OK      | OK             | OK                      | OK |
 | **`github-pr-check`**        | OK      | OK             | OK                      | OK |
 | **`github-pr-review`**       | OK      | OK             | OK                      | Partially Supported [1] |
+| **`github-pr-annotations`**   | OK      | OK             | OK                      | OK |
 | **`gitlab-mr-discussion`**   | OK      | OK             | OK                      | Partially Supported [2] |
 | **`gitlab-mr-commit`**       | OK      | Partially Supported [2] | Partially Supported [2] | Partially Supported [2] |
 | **`gerrit-change-review`**   | OK      | OK? [3]        | OK? [3]                 | Partially Supported? [2][3] |

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -272,9 +272,11 @@ func run(r io.Reader, w io.Writer, opt *option) error {
 	default:
 		return fmt.Errorf("unknown -reporter: %s", opt.reporter)
 	case "github-check":
-		return runDoghouse(ctx, r, w, opt, isProject, false)
+		return runDoghouse(ctx, r, w, opt, isProject, false, false)
 	case "github-pr-check":
-		return runDoghouse(ctx, r, w, opt, isProject, true)
+		return runDoghouse(ctx, r, w, opt, isProject, true, false)
+	case "github-pr-annotations":
+		return runDoghouse(ctx, r, w, opt, isProject, true, true)
 	case "github-pr-review":
 		gs, isPR, err := githubService(ctx, opt)
 		if err != nil {

--- a/doghouse/appengine/checker.go
+++ b/doghouse/appengine/checker.go
@@ -59,7 +59,7 @@ func (gc *githubChecker) handleCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := server.NewChecker(&req, gh).Check(ctx)
+	res, err := server.NewChecker(&req, gh).Check(ctx, true)
 	if err != nil {
 		aelog.Errorf(ctx, "failed to run checker: %v", err)
 		w.WriteHeader(http.StatusBadRequest)

--- a/doghouse/client/client.go
+++ b/doghouse/client/client.go
@@ -19,7 +19,7 @@ const baseEndpoint = "https://reviewdog.app"
 
 // DogHouseClientInterface is interface for doghouse client.
 type DogHouseClientInterface interface {
-	Check(ctx context.Context, req *doghouse.CheckRequest) (*doghouse.CheckResponse, error)
+	Check(ctx context.Context, req *doghouse.CheckRequest, sendRequest bool) (*doghouse.CheckResponse, error)
 }
 
 // DogHouseClient is client for doghouse server.
@@ -48,7 +48,7 @@ func New(client *http.Client) *DogHouseClient {
 }
 
 // Check send check requests to doghouse.
-func (c *DogHouseClient) Check(ctx context.Context, req *doghouse.CheckRequest) (*doghouse.CheckResponse, error) {
+func (c *DogHouseClient) Check(ctx context.Context, req *doghouse.CheckRequest, sendRequest bool) (*doghouse.CheckResponse, error) {
 	checkURL := c.BaseURL.String() + "/check"
 	b, err := json.Marshal(req)
 	if err != nil {

--- a/doghouse/client/client_test.go
+++ b/doghouse/client/client_test.go
@@ -25,7 +25,7 @@ func TestDogHouseClient_Check(t *testing.T) {
 	cli.BaseURL, _ = url.Parse(ts.URL)
 
 	req := &doghouse.CheckRequest{}
-	resp, err := cli.Check(context.Background(), req)
+	resp, err := cli.Check(context.Background(), req, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestDogHouseClient_Check_failure(t *testing.T) {
 	cli.BaseURL, _ = url.Parse(ts.URL)
 
 	req := &doghouse.CheckRequest{}
-	_, err := cli.Check(context.Background(), req)
+	_, err := cli.Check(context.Background(), req, true)
 	if err == nil {
 		t.Error("got no error, but want bad request error")
 	}

--- a/doghouse/client/github_client.go
+++ b/doghouse/client/github_client.go
@@ -15,6 +15,6 @@ type GitHubClient struct {
 	Client *github.Client
 }
 
-func (c *GitHubClient) Check(ctx context.Context, req *doghouse.CheckRequest) (*doghouse.CheckResponse, error) {
-	return server.NewChecker(req, c.Client).Check(ctx)
+func (c *GitHubClient) Check(ctx context.Context, req *doghouse.CheckRequest, makeRequest bool) (*doghouse.CheckResponse, error) {
+	return server.NewChecker(req, c.Client).Check(ctx, makeRequest)
 }

--- a/doghouse/server/doghouse_test.go
+++ b/doghouse/server/doghouse_test.go
@@ -301,7 +301,7 @@ func TestCheck_OK(t *testing.T) {
 		return &github.CheckRun{HTMLURL: github.String(reportURL)}, nil
 	}
 	checker := &Checker{req: req, gh: cli}
-	res, err := checker.Check(context.Background())
+	res, err := checker.Check(context.Background(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func testOutsideDiff(t *testing.T, outsideDiff bool, filterMode filter.Mode) {
 		return &github.CheckRun{HTMLURL: github.String(reportURL)}, nil
 	}
 	checker := &Checker{req: req, gh: cli}
-	if _, err := checker.Check(context.Background()); err != nil {
+	if _, err := checker.Check(context.Background(), true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -480,7 +480,7 @@ func TestCheck_OK_multiple_update_runs(t *testing.T) {
 		return &github.CheckRun{HTMLURL: github.String(reportURL)}, nil
 	}
 	checker := &Checker{req: req, gh: cli}
-	if _, err := checker.Check(context.Background()); err != nil {
+	if _, err := checker.Check(context.Background(), true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -576,7 +576,7 @@ func TestCheck_OK_nonPullRequests(t *testing.T) {
 		return &github.CheckRun{HTMLURL: github.String(reportURL)}, nil
 	}
 	checker := &Checker{req: req, gh: cli}
-	res, err := checker.Check(context.Background())
+	res, err := checker.Check(context.Background(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -597,7 +597,7 @@ func TestCheck_fail_diff(t *testing.T) {
 	}
 	checker := &Checker{req: req, gh: cli}
 
-	if _, err := checker.Check(context.Background()); err == nil {
+	if _, err := checker.Check(context.Background(), true); err == nil {
 		t.Fatalf("got no error, want some error")
 	} else {
 		t.Log(err)
@@ -616,7 +616,7 @@ func TestCheck_fail_invalid_diff(t *testing.T) {
 	}
 	checker := &Checker{req: req, gh: cli}
 
-	if _, err := checker.Check(context.Background()); err == nil {
+	if _, err := checker.Check(context.Background(), true); err == nil {
 		t.Fatalf("got no error, want some error")
 	} else {
 		t.Log(err)
@@ -634,7 +634,7 @@ func TestCheck_fail_check(t *testing.T) {
 	}
 	checker := &Checker{req: req, gh: cli}
 
-	if _, err := checker.Check(context.Background()); err == nil {
+	if _, err := checker.Check(context.Background(), true); err == nil {
 		t.Fatalf("got no error, want some error")
 	} else {
 		t.Log(err)
@@ -656,7 +656,7 @@ func TestCheck_fail_check_with_403(t *testing.T) {
 	}
 	checker := &Checker{req: req, gh: cli}
 
-	resp, err := checker.Check(context.Background())
+	resp, err := checker.Check(context.Background(), true)
 	if err != nil {
 		t.Fatalf("got unexpected error: %v", err)
 	}

--- a/project/run_test.go
+++ b/project/run_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -162,7 +163,12 @@ func TestRun(t *testing.T) {
 		} else {
 			t.Log(err)
 		}
-		want := "sh: 1: not-found: not found\n"
+		var want string
+		if runtime.GOOS == "darwin" {
+			want = "sh: not-found: command not found\n"
+		} else {
+			want = "sh: 1: not-found: not found\n"
+		}
 		if got := buf.String(); got != want {
 			t.Errorf("got stderr %q, want %q", got, want)
 		}


### PR DESCRIPTION
## Feature Description

This PR adds a new `github-pr-annotations` reporter which bypasses the checks API and uses the existing GitHub annotations fallback to report failures.

It _should_ resolve #403 and allow people to attach annotations in the same check that runs reviewdog.

## Testing

I've updated all existing tests so that they pass again. I tried to add a test for the GH Actions annotation format specifically, but `core.Error` in `go-actions-toolkit` is hardcoded to write to `os.stdout` which means I can't capture the output to write assertions

## Checklist

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

