### PR TITLE
doghouse: bump Go 1.21

### DIFF
--- a/.github/workflows/deploy-doghouse.yml
+++ b/.github/workflows/deploy-doghouse.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # must sync doghouse/appengine/app.yaml
-          go-version: "1.20"
+          go-version: "1.21"
       - run: go test -v -race  ./...
   deploy:
     permissions:

--- a/doghouse/appengine/app.yaml
+++ b/doghouse/appengine/app.yaml
@@ -1,7 +1,7 @@
 # reviewdog app config: https://github.com/settings/apps/reviewdog
 
 # https://cloud.google.com/appengine/docs/standard/go/config/appref
-runtime: go120
+runtime: go121
 
 # https://cloud.google.com/appengine/docs/standard/go/warmup-requests/configuring
 inbound_services:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/reviewdog/reviewdog
 
-go 1.21
-
-toolchain go1.21.0
+go 1.21.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
Go 1.21 is now [generally available](https://cloud.google.com/products/#product-launch-stages) on App Engine.

https://cloud.google.com/appengine/docs/standard/go/release-notes#September_14_2023

<img width="935" alt="image" src="https://github.com/reviewdog/reviewdog/assets/1157344/f4d9c96d-3dd6-42d4-8153-32eb7ad57d51">
