### PR TITLE
Use builtin min and max

### DIFF
--- a/.github/workflows/deploy-doghouse.yml
+++ b/.github/workflows/deploy-doghouse.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # must sync doghouse/appengine/app.yaml
-          go-version: "1.20"
+          go-version: "1.21"
       - run: go test -v -race  ./...
   deploy:
     permissions:

--- a/doghouse/appengine/app.yaml
+++ b/doghouse/appengine/app.yaml
@@ -1,7 +1,7 @@
 # reviewdog app config: https://github.com/settings/apps/reviewdog
 
 # https://cloud.google.com/appengine/docs/standard/go/config/appref
-runtime: go120
+runtime: go121
 
 # https://cloud.google.com/appengine/docs/standard/go/warmup-requests/configuring
 inbound_services:

--- a/doghouse/server/doghouse.go
+++ b/doghouse/server/doghouse.go
@@ -387,10 +387,3 @@ func annotationToDiagnostic(a *doghouse.Annotation) *rdf.Diagnostic {
 		OriginalOutput: a.RawMessage,
 	}
 }
-
-func min(x, y int) int {
-	if x > y {
-		return y
-	}
-	return x
-}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/reviewdog/reviewdog
 
-go 1.21
-
-toolchain go1.21.0
+go 1.21.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -475,10 +475,3 @@ func getSourceLine(sourceLines map[int]string, line int) (string, error) {
 	}
 	return lineContent, nil
 }
-
-func max(x, y int32) int32 {
-	if x < y {
-		return y
-	}
-	return x
-}


### PR DESCRIPTION
From Go 1.21, built-in function `min` and `max` are available.

This pull request includes the changes of https://github.com/reviewdog/reviewdog/pull/1647

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

