### PR TITLE
Introduce slog

### DIFF
--- a/.github/workflows/deploy-doghouse.yml
+++ b/.github/workflows/deploy-doghouse.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # must sync doghouse/appengine/app.yaml
-          go-version: "1.20"
+          go-version: "1.21"
       - run: go test -v -race  ./...
   deploy:
     permissions:

--- a/doghouse/appengine/app.yaml
+++ b/doghouse/appengine/app.yaml
@@ -1,7 +1,7 @@
 # reviewdog app config: https://github.com/settings/apps/reviewdog
 
 # https://cloud.google.com/appengine/docs/standard/go/config/appref
-runtime: go120
+runtime: go121
 
 # https://cloud.google.com/appengine/docs/standard/go/warmup-requests/configuring
 inbound_services:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/reviewdog/reviewdog
 
-go 1.21
-
-toolchain go1.21.0
+go 1.21.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
Starting from Go 1.21, log/slog is available as a standard library. I think it's a very good option for starting with structured logging.

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

