### PR TITLE
extend golangci-lint timeout

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--enable-all --exclude-use-default=false -D wsl -D testpackage"
+          golangci_lint_flags: "--enable-all --exclude-use-default=false -D wsl -D testpackage --timeout 2m"
           level: "warning"
           reporter: github-pr-check
 


### PR DESCRIPTION
golangci-lint workflow sometimes fails with timeout error: https://github.com/reviewdog/reviewdog/actions/runs/7627118782/job/20775054992?pr=1649

```
   level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
Error: Error: golangci-lint exited with status code: 4
```

This pull request will fix it.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

