### PR TITLE
Fix sending wrong line number to Bitbucket Server Code Insight Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :bug: Fixes
 - [#1651](https://github.com/reviewdog/reviewdog/pull/1651) Revert #1576: Support `--filter-mode=file` in `github-pr-review`. Reasons: #1645
 - [#1653](https://github.com/reviewdog/reviewdog/pull/1653) fix: SARIF parser: parse with no region result. fix originalOutput field
+- [#1657](https://github.com/reviewdog/reviewdog/pull/1657) Fix sending incorrect line numbers to BitBucket Server Code Insight API. (fixes #1652)
 - ...
 
 ### :rotating_light: Breaking changes

--- a/service/bitbucket/server_api_helper.go
+++ b/service/bitbucket/server_api_helper.go
@@ -42,7 +42,7 @@ func (h *ServerAPIHelper) buildAnnotation(comment *reviewdog.Comment) insights.A
 
 	data := insights.NewAnnotation(
 		comment.Result.Diagnostic.GetLocation().GetPath(),
-		comment.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine()-1,
+		comment.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine(),
 		fmt.Sprintf(`[%s] %s`, comment.ToolName, comment.Result.Diagnostic.GetMessage()),
 		severity,
 	)


### PR DESCRIPTION
Fixed sending wrong line number to Bitbucket Server Code Insight Reports (fixes #1652)

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

