### PR TITLE
CI: stop using golangci-lint --enable-all

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--enable-all --exclude-use-default=false -D wsl -D testpackage --timeout 2m"
+          golangci_lint_flags: "--timeout 2m"
           level: "warning"
           reporter: github-pr-check
 


### PR DESCRIPTION
goalngci-lint fail infrequently with --enable-all.
We actually do not need to run all linters.
The original reason I used --enabled-all is just for illustration
purpose.

It might be better to configure our own golangci-lint, but for now let's
use default linters.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

