### PR TITLE
feat: Disable the "reported by reviewdog 🐶" Prefix in Review Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ github-pr-annotations uses the GitHub Actions annotation format to output errors
 and warnings to `stdout` e.g.
 
 ```
-::error line=11,col=41,file=app/index.md::[vale] reported by reviewdog 🐶%0A[demo.Spelling] Did you really mean 'boobarbaz'?%0A%0ARaw Output:%0A{"message": "[demo.Spelling] Did you really mean 'boobarbaz'?", "location": {"path": "app/index.md", "range": {"start": {"line": 11, "column": 41}}}, "severity": "ERROR"}
+::error line=11,col=41,file=app/index.md::[vale]%0A[demo.Spelling] Did you really mean 'boobarbaz'?%0A%0ARaw Output:%0A{"message": "[demo.Spelling] Did you really mean 'boobarbaz'?", "location": {"path": "app/index.md", "range": {"start": {"line": 11, "column": 41}}}, "severity": "ERROR"}
 ```
 
 This reporter requires a valid GitHub API token to generate a diff, but will not

--- a/service/github/githubutils/comment_writer.go
+++ b/service/github/githubutils/comment_writer.go
@@ -49,7 +49,7 @@ func (lw *GitHubActionLogWriter) Flush(_ context.Context) error {
 // annotations.
 // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#example-5
 func ReportAsGitHubActionsLog(toolName, defaultLevel string, d *rdf.Diagnostic) {
-	mes := fmt.Sprintf("[%s] reported by reviewdog 🐶\n%s\n\nRaw Output:\n%s",
+	mes := fmt.Sprintf("[%s]\n%s\n\nRaw Output:\n%s",
 		toolName, d.GetMessage(), d.GetOriginalOutput())
 	loc := d.GetLocation()
 	start := loc.GetRange().GetStart()


### PR DESCRIPTION
ref. #1662 

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

## Change List

- delete: the prefix "reported by reviewdog 🐶" whenever reviewdog comment
- update: README