### PR TITLE
fix: use urlencoded namespace to query gitlab

### DIFF
--- a/service/gitlab/gitlab_mr_commit.go
+++ b/service/gitlab/gitlab_mr_commit.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -50,7 +51,7 @@ func NewGitLabMergeRequestCommitCommenter(cli *gitlab.Client, owner, repo string
 		cli:      cli,
 		pr:       pr,
 		sha:      sha,
-		projects: owner + "/" + repo,
+		projects: url.QueryEscape(owner + "/" + repo),
 		wd:       workDir,
 	}, nil
 }

--- a/service/gitlab/gitlab_mr_commit_test.go
+++ b/service/gitlab/gitlab_mr_commit_test.go
@@ -24,7 +24,7 @@ func TestGitLabMergeRequestCommitCommenter_Post_Flush_review_api(t *testing.T) {
 
 	apiCalled := 0
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v4/projects/o/r/merge_requests/14/commits", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/commits", func(w http.ResponseWriter, r *http.Request) {
 		apiCalled++
 		if r.Method != http.MethodGet {
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
@@ -39,7 +39,7 @@ func TestGitLabMergeRequestCommitCommenter_Post_Flush_review_api(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	mux.HandleFunc("/api/v4/projects/o/r/repository/commits/0123456789abcdef/comments", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/o%2Fr/repository/commits/0123456789abcdef/comments", func(w http.ResponseWriter, r *http.Request) {
 		apiCalled++
 		if r.Method != http.MethodGet {
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
@@ -55,7 +55,7 @@ func TestGitLabMergeRequestCommitCommenter_Post_Flush_review_api(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	mux.HandleFunc("/api/v4/projects/o/r/repository/commits/sha/comments", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/o%2Fr/repository/commits/sha/comments", func(w http.ResponseWriter, r *http.Request) {
 		apiCalled++
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)

--- a/service/gitlab/gitlab_mr_diff.go
+++ b/service/gitlab/gitlab_mr_diff.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -37,7 +38,7 @@ func NewGitLabMergeRequestDiff(cli *gitlab.Client, owner, repo string, pr int, s
 		cli:      cli,
 		pr:       pr,
 		sha:      sha,
-		projects: owner + "/" + repo,
+		projects: url.QueryEscape(owner + "/" + repo),
 		wd:       workDir,
 	}, nil
 }

--- a/service/gitlab/gitlab_mr_diff_test.go
+++ b/service/gitlab/gitlab_mr_diff_test.go
@@ -13,7 +13,7 @@ func TestGitLabMergeRequestDiff_Diff(t *testing.T) {
 	getMRAPICall := 0
 	getBranchAPICall := 0
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v4/projects/o/r/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
 		getMRAPICall++
 		if r.Method != http.MethodGet {
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)

--- a/service/gitlab/gitlab_mr_discussion.go
+++ b/service/gitlab/gitlab_mr_discussion.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -52,7 +53,7 @@ func NewGitLabMergeRequestDiscussionCommenter(cli *gitlab.Client, owner, repo st
 		cli:      cli,
 		pr:       pr,
 		sha:      sha,
-		projects: owner + "/" + repo,
+		projects: url.QueryEscape(owner + "/" + repo),
 		wd:       workDir,
 	}, nil
 }

--- a/service/gitlab/gitlab_mr_discussion_test.go
+++ b/service/gitlab/gitlab_mr_discussion_test.go
@@ -293,7 +293,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
 		}
 	})
-	mux.HandleFunc("/api/v4/projects/o/r/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
 		}


### PR DESCRIPTION
This PR changes how reviewdog queries the gitlab api.  
It now uses the urlencoded namespace as required according to the documentation.
https://docs.gitlab.com/ee/api/rest/#namespaced-path-encoding 

fixes #1672 

TODOS:
- [ ] Test the changes with a local gitlab instance. 
- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

