### PR TITLE
close datastore.Client

### DIFF
--- a/doghouse/server/storage/installation.go
+++ b/doghouse/server/storage/installation.go
@@ -41,6 +41,7 @@ func (g *GitHubInstallationDatastore) Put(ctx context.Context, inst *GitHubInsta
 	if err != nil {
 		return err
 	}
+	defer d.Close()
 	_, err = d.RunInTransaction(ctx, func(t *datastore.Transaction) error {
 		var foundInst GitHubInstallation
 		var ok bool
@@ -68,6 +69,7 @@ func (g *GitHubInstallationDatastore) Get(ctx context.Context, accountName strin
 	if err != nil {
 		return false, nil, err
 	}
+	defer d.Close()
 	if err := d.Get(ctx, key, inst); err != nil {
 		if err == datastore.ErrNoSuchEntity {
 			return false, nil, nil

--- a/doghouse/server/storage/token.go
+++ b/doghouse/server/storage/token.go
@@ -44,6 +44,7 @@ func (g *GitHubRepoTokenDatastore) Put(ctx context.Context, token *GitHubReposit
 	if err != nil {
 		return err
 	}
+	defer d.Close()
 	_, err = d.Put(ctx, key, token)
 	return err
 }
@@ -55,6 +56,7 @@ func (g *GitHubRepoTokenDatastore) Get(ctx context.Context, owner, repo string) 
 	if err != nil {
 		return false, nil, err
 	}
+	defer d.Close()
 	if err := d.Get(ctx, key, token); err != nil {
 		if err == datastore.ErrNoSuchEntity {
 			return false, nil, nil


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
    - It's not a notable change.

Hi, I found closers that aren't closed in doghouse. Since it's minor fix, feel free to ignore this.

Go Doc comment on `datastore.NewClient` says:
```go
// Call (*Client).Close() when done with the client.
```
Implementation of `(*Client).Close()` looks to close connection pooling.
```go
// Close closes the Client. Call Close to clean up resources when done with the
// Client.
func (c *Client) Close() error {
	return c.connPool.Close()
}
```
So it looks better to be closed.

Adding context, I'm not familiar doghouse at all (though I'm interested in reviewdog). Even I don't know how to run doghouse (https://github.com/reviewdog/reviewdog/issues/1194). I'm developing a static code analyzer and randomly scanning open projects to find practical false positives so that I can improve recall of the analyzer. I just found this problem by the analyzer and consider it's a true positive.