### PR TITLE
CI reviewdog: Use local reporter with pull requests from forked repositories

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -28,24 +30,30 @@ jobs:
         run: |
           go install ./cmd/reviewdog
 
+      - if: github.repository == github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-reporter=github-check" >> $GITHUB_ENV
+
+      - if: github.repository != github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-diff='git diff ${{github.event.pull_request.base.sha}} ${{github.event.pull_request.head.sha}}'" >> $GITHUB_ENV
+
       - name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          golint ./... | reviewdog -f=golint -name=golint-github-check -reporter=github-check -level=warning
+          golint ./... | eval reviewdog -f=golint -name=golint-github-check $REVIEWDOG_FLAG -level=warning
 
       - name: Run reviewdog with sub-dir (github-check)
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd ./_testdata/ && golint ./... | reviewdog -f=golint -name=golint-check-subdir -reporter=github-check -level=info -filter-mode=nofilter
+          cd ./_testdata/ && golint ./... | eval reviewdog -f=golint -name=golint-check-subdir $REVIEWDOG_FLAG -level=info -filter-mode=nofilter
 
       - name: Custom rdjson test (github-check)
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat ./_testdata/custom_rdjson.json | \
-            reviewdog -name="custom-rdjson" -f=rdjson -reporter=github-check -level=info
+            eval reviewdog -name="custom-rdjson" -f=rdjson $REVIEWDOG_FLAG -level=info
 
   reviewdog-pr:
     permissions:
@@ -57,6 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -127,12 +137,16 @@ jobs:
           cd ./_testdata/ && reviewdog -conf=reviewdog_error.yml \
             -reporter=github-pr-review || EXIT_CODE=$?
           test "${EXIT_CODE}" = 1
+      - if: github.repository == github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-reporter=github-check" >> $GITHUB_ENV
+      - if: github.repository != github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-diff='git diff ${{github.event.pull_request.base.sha}} ${{github.event.pull_request.head.sha}}'" >> $GITHUB_ENV
       - name: Unexpected failure (github-check)
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd ./_testdata/ && reviewdog -conf=reviewdog_error.yml \
-            -reporter=github-check || EXIT_CODE=$?
+          cd ./_testdata/ && eval reviewdog -conf=reviewdog_error.yml \
+            $REVIEWDOG_FLAG || EXIT_CODE=$?
           test "${EXIT_CODE}" = 1
       - name: Unexpected failure (local)
         run: |
@@ -250,25 +264,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: reviewdog/action-setup@v1
       - run: npm install
+      - if: github.repository == github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-reporter=github-check" >> $GITHUB_ENV
+      - if: github.repository != github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-diff='git diff ${{github.event.pull_request.base.sha}} ${{github.event.pull_request.head.sha}}'" >> $GITHUB_ENV
       - name: textlint
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx textlint -f checkstyle README.md | \
-            reviewdog -f=checkstyle -name="textlint" -reporter=github-check -level=info
+            eval reviewdog -f=checkstyle -name="textlint" $REVIEWDOG_FLAG -level=info
 
   sarif:
     name: runner / textlint sarif
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: reviewdog/action-setup@v1
       - run: npm install
+      - if: github.repository == github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-reporter=github-check" >> $GITHUB_ENV
+      - if: github.repository != github.event.pull_request.head.repo.full_name
+        run: echo "REVIEWDOG_FLAG=-diff='git diff ${{github.event.pull_request.base.sha}} ${{github.event.pull_request.head.sha}}'" >> $GITHUB_ENV
       - name: textlint sarif
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx textlint -f @microsoft/eslint-formatter-sarif README.md | \
-            reviewdog -f=sarif -name="textlint" -reporter=github-check -level=info
+            eval reviewdog -f=sarif -name="textlint" $REVIEWDOG_FLAG -level=info


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
  - it's not notable changes.

https://github.com/reviewdog/reviewdog/actions/runs/8510418885/job/23307964887?pr=1697

```
reviewdog: This GitHub token doesn't have write permission of Review API [1], 
so reviewdog will report results via logging command [2] and create annotations similar to
github-pr-check reporter as a fallback.
[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target, 
[2]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands
```

When I submit a pull request from a forked repository, CI `reviewdog` fails because I don't have write permission of review API.
Therefore, when I submit a pull request from a forked repository, it uses the local reporter.
