### PR TITLE
Fix: change brews.folder to brews.directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ brews:
   - repository:
       owner: reviewdog
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     homepage: https://github.com/reviewdog/reviewdog
     description: Automated code review tool integrated with any code analysis tools regardless of programming language.
     test: |


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
   - it's not notable changes.

https://github.com/reviewdog/reviewdog/actions/runs/8662593699/job/23754853000

```
  • DEPRECATED: brews.folder should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.25.1/x64/goreleaser' failed with exit code 2
```

https://goreleaser.com/deprecations/#brewsfolder
I change `brews.folder` to `brews.directory` in `.goreleaser.yml` because `brews.folder` was renamed in goreleaser v1.25.