### PR TITLE
ci: change --rm-dist to --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         if: "steps.tag.outputs.value != ''"
         with:
           version: latest
-          args: release --rm-dist --release-header .github/goreleaser-header.md
+          args: release --clean --release-header .github/goreleaser-header.md
         env:
           # Need to use personal access token instead of default token to
           # update https://github.com/reviewdog/homebrew-tap.


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
   - it's not notable changes.

https://github.com/reviewdog/reviewdog/actions/runs/8688102935/job/23822999680

```
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```

https://goreleaser.com/deprecations/#-rm-dist

`--rm-dist` has been deprecated in favor of `--clean` in goreleaser v1.15.0.
Therefore, I change `--rm-dist` to `--clean`.