### PR TITLE
rdf: Discard unknown fields when unmarshalling JSON data

### DIFF
--- a/parser/rdjson.go
+++ b/parser/rdjson.go
@@ -26,7 +26,7 @@ func (p *RDJSONParser) Parse(r io.Reader) ([]*rdf.Diagnostic, error) {
 		return nil, err
 	}
 	var dr rdf.DiagnosticResult
-	if err := protojson.Unmarshal(b, &dr); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(b, &dr); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal rdjson (DiagnosticResult): %w", err)
 	}
 	for _, d := range dr.Diagnostics {

--- a/parser/rdjson_test.go
+++ b/parser/rdjson_test.go
@@ -75,7 +75,8 @@ func ExampleRDJSONParser() {
           }
         }
       },
-      "severity": 1
+      "severity": 1,
+      "unknown_field": "this field will be ignored"
     }
   ]
 }`

--- a/parser/rdjsonl.go
+++ b/parser/rdjsonl.go
@@ -26,7 +26,7 @@ func (p *RDJSONLParser) Parse(r io.Reader) ([]*rdf.Diagnostic, error) {
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		d := new(rdf.Diagnostic)
-		if err := protojson.Unmarshal(s.Bytes(), d); err != nil {
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(s.Bytes(), d); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal rdjsonl (Diagnostic): %w", err)
 		}
 		if d.GetOriginalOutput() == "" {

--- a/parser/rdjsonl_test.go
+++ b/parser/rdjsonl_test.go
@@ -12,7 +12,7 @@ func TestRDJSONLParser(t *testing.T) {
 {"source":{"name":"ineffassign"},"message":"ineffectual assignment to 'x'","location":{"path":"testdata/main.go","range":{"start":{"line":12,"column":2}}}}
 {"source":{"name":"govet"},"message":"printf: Sprintf format %d reads arg #1, but call has 0 args","location":{"path":"testdata/main.go","range":{"start":{"line":13,"column":2}}}}
 {"source":{"name":"severity-test"},"message":"severity test (string)","location":{"path":"testdata/main.go","range":{"start":{"line":24,"column":6}}}, "severity": "WARNING"}
-{"source":{"name":"severity-test"},"message":"severity test (number)","location":{"path":"testdata/main.go","range":{"start":{"line":24,"column":6}}}, "severity": "WARNING"}`
+{"source":{"name":"severity-test"},"message":"severity test (number)","location":{"path":"testdata/main.go","range":{"start":{"line":24,"column":6}}}, "severity": "WARNING", "unknown_field": "this field will be ignored"}`
 	sampleLines := strings.Split(sample, "\n")
 	p := NewRDJSONLParser()
 	diagnostics, err := p.Parse(strings.NewReader(sample))


### PR DESCRIPTION
Old reviewdog binaries should succeed in parseing given rdjson/rdjsonl
correctly when RDFormat is updated and new fields are added.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

