### PR TITLE
Update README.md to add action-regal

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,9 @@ You can use public GitHub Actions to start using reviewdog with ease! :tada: :ar
   - [reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint) - Run [actionlint](https://github.com/rhysd/actionlint)
 - Protocol Buffers
   - [yoheimuta/action-protolint](https://github.com/yoheimuta/action-protolint) - Run [protolint](https://github.com/yoheimuta/protolint)
-  
+- Rego
+  - [reviewdog/action-regal](https://github.com/reviewdog/action-regal) - Run [Regal](https://github.com/StyraInc/regal)
+
 ... and more on [GitHub Marketplace](https://github.com/marketplace?utf8=✓&type=actions&query=reviewdog).
 
 Missing actions? Check out [reviewdog/action-template](https://github.com/reviewdog/action-template) and create a new reviewdog action!


### PR DESCRIPTION
I want to add `action-regal` to the README.md

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

