### PR TITLE
Update Download stats badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
   <a href="https://github.com/reviewdog/.github/blob/master/CODE_OF_CONDUCT.md">
     <img alt="Contributor Covenant" src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg">
   </a>
-  <a href="https://somsubhra.github.io/github-release-stats/?username=reviewdog&repository=reviewdog&per_page=30">
+  <a href="https://haya14busa.github.io/github-release-stats/#reviewdog/reviewdog">
     <img alt="GitHub Releases Stats" src="https://img.shields.io/github/downloads/reviewdog/reviewdog/total.svg?logo=github">
   </a>
   <a href="https://starchart.cc/reviewdog/reviewdog"><img alt="Stars" src="https://img.shields.io/github/stars/reviewdog/reviewdog.svg?style=social"></a>


### PR DESCRIPTION
Use https://haya14busa.github.io/github-release-stats/#reviewdog/reviewdog instead


- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

