### PR TITLE
Implement rdjson and rdjsonl reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- ...
+- [#1806](https://github.com/reviewdog/reviewdog/pull/1806) Add -reporter=rdjson/rdjsonl which outputs rdjson/rdjsonl format to stdout. It also changes the default behavior of -diff and -filter-mode for local reporters. If -filter-mode is not provided (-filter-mode=default) and -diff flag is not provided, reviewdog automatically set -filter-mode=nofilter.
 
 ### :bug: Fixes
 - ...

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -93,10 +93,10 @@ const (
 	"local" (default)
 		Report results to stdout.
 
-	"rjson"
+	"rdjson"
 		Report results to stdout in rdjson format.
 
-	"rjsonl"
+	"rdjsonl"
 		Report results to stdout in rdjsonl format.
 
 	"github-check"

--- a/cmd/reviewdog/main_test.go
+++ b/cmd/reviewdog/main_test.go
@@ -83,10 +83,11 @@ func TestRun_local_nofilter(t *testing.T) {
 	)
 
 	opt := &option{
-		diffCmd:   "", // empty
-		efms:      strslice([]string{`%f(%l,%c): %m`}),
-		diffStrip: 0,
-		reporter:  "local",
+		diffCmd:    "", // empty
+		efms:       strslice([]string{`%f(%l,%c): %m`}),
+		diffStrip:  0,
+		reporter:   "local",
+		filterMode: filter.ModeAdded,
 	}
 
 	stdout := new(bytes.Buffer)

--- a/comment_iowriter.go
+++ b/comment_iowriter.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+
+	"github.com/reviewdog/reviewdog/proto/rdf"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var _ CommentService = &RawCommentWriter{}
@@ -55,4 +58,87 @@ func (mc *UnifiedCommentWriter) Post(_ context.Context, c *Comment) error {
 	s += fmt.Sprintf(": [%s] %s", c.ToolName, c.Result.Diagnostic.GetMessage())
 	_, err := fmt.Fprintln(mc.w, s)
 	return err
+}
+
+var _ CommentService = &RDJSONLCommentWriter{}
+
+// RDJSONLCommentWriter
+type RDJSONLCommentWriter struct {
+	w io.Writer
+}
+
+func NewRDJSONLCommentWriter(w io.Writer) *RDJSONLCommentWriter {
+	return &RDJSONLCommentWriter{w: w}
+}
+
+func (cw *RDJSONLCommentWriter) Post(_ context.Context, c *Comment) error {
+	if c.ToolName != "" && c.Result.Diagnostic.GetSource().GetName() == "" {
+		c.Result.Diagnostic.Source = &rdf.Source{
+			Name: c.ToolName,
+		}
+	}
+	b, err := protojson.MarshalOptions{
+		UseProtoNames:     true,
+		UseEnumNumbers:    false,
+		Multiline:         false,
+		EmitUnpopulated:   false,
+		EmitDefaultValues: false,
+	}.Marshal(c.Result.Diagnostic)
+	if err != nil {
+		return err
+	}
+	if _, err = cw.w.Write(b); err != nil {
+		return err
+	}
+	if _, err := cw.w.Write([]byte("\n")); err != nil {
+		return err
+	}
+	return nil
+}
+
+var _ CommentService = &RDJSONCommentWriter{}
+
+// RDJSONCommentWriter
+type RDJSONCommentWriter struct {
+	w        io.Writer
+	comments []*Comment
+	toolName string
+}
+
+func NewRDJSONCommentWriter(w io.Writer, toolName string) *RDJSONCommentWriter {
+	return &RDJSONCommentWriter{w: w, toolName: toolName}
+}
+
+func (cw *RDJSONCommentWriter) Post(_ context.Context, c *Comment) error {
+	cw.comments = append(cw.comments, c)
+	return nil
+}
+
+func (cw *RDJSONCommentWriter) Flush(_ context.Context) error {
+	result := &rdf.DiagnosticResult{
+		Source: &rdf.Source{
+			Name: cw.toolName,
+		},
+		Diagnostics: make([]*rdf.Diagnostic, 0, len(cw.comments)),
+	}
+	for _, c := range cw.comments {
+		result.Diagnostics = append(result.Diagnostics, c.Result.Diagnostic)
+	}
+	b, err := protojson.MarshalOptions{
+		UseProtoNames:     true,
+		UseEnumNumbers:    false,
+		Multiline:         true,
+		EmitUnpopulated:   false,
+		EmitDefaultValues: false,
+	}.Marshal(result)
+	if err != nil {
+		return err
+	}
+	if _, err = cw.w.Write(b); err != nil {
+		return err
+	}
+	if _, err := cw.w.Write([]byte("\n")); err != nil {
+		return err
+	}
+	return nil
 }

--- a/comment_iowriter_test.go
+++ b/comment_iowriter_test.go
@@ -3,6 +3,7 @@ package reviewdog
 import (
 	"bytes"
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -252,7 +253,9 @@ func TestRDJSONCommentWriter_Post(t *testing.T) {
     "name": "tool name [constructor]"
   }
 }`
-	if got := strings.TrimSpace(buf.String()); got != strings.TrimSpace(want) {
+	re := regexp.MustCompile(`:\s+`)
+	got := re.ReplaceAllString(strings.TrimSpace(buf.String()), ":")
+	if got != re.ReplaceAllString(strings.TrimSpace(want), ":") {
 		t.Errorf("got\n%v\nwant:\n%v", got, want)
 	}
 }

--- a/comment_iowriter_test.go
+++ b/comment_iowriter_test.go
@@ -93,3 +93,166 @@ line2`,
 		}
 	}
 }
+
+func TestRDJSONLCommentWriter_Post(t *testing.T) {
+	tests := []struct {
+		in   *Comment
+		want string
+	}{
+		{
+			in: &Comment{
+				Result: &filter.FilteredDiagnostic{
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{Path: "/path/to/file"},
+						Message:  "message",
+					},
+				},
+				ToolName: "tool name",
+			},
+			want: `{"message":"message","location":{"path":"/path/to/file"},"source":{"name":"tool name"}}`,
+		},
+		{
+			in: &Comment{
+				Result: &filter.FilteredDiagnostic{
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{
+							Path: "/path/to/file",
+							Range: &rdf.Range{Start: &rdf.Position{
+								Column: 14,
+							}},
+						},
+						Message: "message",
+					},
+				},
+			},
+			want: `{"message":"message","location":{"path":"/path/to/file","range":{"start":{"column":14}}}}`,
+		},
+		{
+			in: &Comment{
+				Result: &filter.FilteredDiagnostic{
+					Diagnostic: &rdf.Diagnostic{
+						Location: &rdf.Location{
+							Path: "/path/to/file",
+							Range: &rdf.Range{Start: &rdf.Position{
+								Column: 14,
+							}},
+						},
+						Message: "message",
+						Source: &rdf.Source{
+							Name: "tool name in Diagnostic",
+							Url:  "tool url",
+						},
+					},
+				},
+			},
+			want: `{"message":"message","location":{"path":"/path/to/file","range":{"start":{"column":14}}},"source":{"name":"tool name in Diagnostic","url":"tool url"}}`,
+		},
+	}
+	for _, tt := range tests {
+		buf := new(bytes.Buffer)
+		cw := NewRDJSONLCommentWriter(buf)
+		if err := cw.Post(context.Background(), tt.in); err != nil {
+			t.Error(err)
+			continue
+		}
+		if got := strings.ReplaceAll(strings.Trim(buf.String(), "\n"), `, "`, `,"`); got != tt.want {
+			t.Errorf("RDJSONLCommentWriter.Post(%v) = \n%v\nwant:\n%v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRDJSONCommentWriter_Post(t *testing.T) {
+	comments := []*Comment{
+		{
+			Result: &filter.FilteredDiagnostic{
+				Diagnostic: &rdf.Diagnostic{
+					Location: &rdf.Location{Path: "/path/to/file"},
+					Message:  "message",
+				},
+			},
+			ToolName: "tool name",
+		},
+		{
+			Result: &filter.FilteredDiagnostic{
+				Diagnostic: &rdf.Diagnostic{
+					Location: &rdf.Location{
+						Path: "/path/to/file",
+						Range: &rdf.Range{Start: &rdf.Position{
+							Column: 14,
+						}},
+					},
+					Message: "message",
+				},
+			},
+		},
+		{
+			Result: &filter.FilteredDiagnostic{
+				Diagnostic: &rdf.Diagnostic{
+					Location: &rdf.Location{
+						Path: "/path/to/file",
+						Range: &rdf.Range{Start: &rdf.Position{
+							Column: 14,
+						}},
+					},
+					Message: "message",
+					Source: &rdf.Source{
+						Name: "tool name in Diagnostic",
+						Url:  "tool url",
+					},
+				},
+			},
+		},
+	}
+	buf := new(bytes.Buffer)
+	cw := NewRDJSONCommentWriter(buf, "tool name [constructor]")
+	for _, c := range comments {
+		if err := cw.Post(context.Background(), c); err != nil {
+			t.Error(err)
+		}
+	}
+	if err := cw.Flush(context.Background()); err != nil {
+		t.Error(err)
+	}
+	want := `{
+  "diagnostics": [
+    {
+      "message": "message",
+      "location": {
+        "path": "/path/to/file"
+      }
+    },
+    {
+      "message": "message",
+      "location": {
+        "path": "/path/to/file",
+        "range": {
+          "start": {
+            "column": 14
+          }
+        }
+      }
+    },
+    {
+      "message": "message",
+      "location": {
+        "path": "/path/to/file",
+        "range": {
+          "start": {
+            "column": 14
+          }
+        }
+      },
+      "source": {
+        "name": "tool name in Diagnostic",
+        "url": "tool url"
+      }
+    }
+  ],
+  "source": {
+    "name": "tool name [constructor]"
+  }
+}`
+	if got := strings.TrimSpace(buf.String()); got != strings.TrimSpace(want) {
+		t.Errorf("got\n%v\nwant:\n%v", got, want)
+	}
+}


### PR DESCRIPTION
It reports output to stdout in rdjson/rdjsonl format.

It also changes the default behavior of -filter-mode and -diff command
behavior for local (local/rdjson/rdjsonl) reporters.
If -filter-mode is not provided (-filter-mode=default) and -diff flag is
not provided, reviewdog automatically set -filter-mode=nofilter.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

