### PR TITLE
Update CircleCI's golang image to 1.21.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang-executor:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.21.7
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,14 @@
-version: 2
+version: 2.1
+
+executors:
+  golang-executor:
+    docker:
+      - image: circleci/golang:1.17
 
 jobs:
   lint:
     working_directory: ~/reviewdog
-    docker:
-      - image: circleci/golang:1.17
+    executor: golang-executor
     steps:
       - checkout
       - run:


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
   - It's not notable changes.

I update CircleCI's golang image to 1.21.7 and switch from `circleci/golang` image to `cimg/go` image: https://circleci.com/developer/en/images/image/cimg/go
In addition, we have also changed to using an `executor`: https://circleci.com/docs/en/configuration-reference/#executors