### PR TITLE
trigger-depup: Exclude archived repositories

### DIFF
--- a/scripts/trigger-depup/main.go
+++ b/scripts/trigger-depup/main.go
@@ -46,7 +46,7 @@ func run() error {
 	}
 	var wholeErr error
 	for _, repo := range repos {
-		if !strings.HasPrefix(repo.GetName(), "action-") || repo.GetName() == "action-eclint" {
+		if repo.GetArchived() || !strings.HasPrefix(repo.GetName(), "action-") {
 			continue
 		}
 		log.Printf("Dispatch depup to %s/%s...", *targetOrg, repo.GetName())

--- a/scripts/trigger-depup/main.go
+++ b/scripts/trigger-depup/main.go
@@ -46,7 +46,7 @@ func run() error {
 	}
 	var wholeErr error
 	for _, repo := range repos {
-		if !strings.HasPrefix(repo.GetName(), "action-") {
+		if !strings.HasPrefix(repo.GetName(), "action-") || repo.GetName() == "action-eclint" {
 			continue
 		}
 		log.Printf("Dispatch depup to %s/%s...", *targetOrg, repo.GetName())


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
   - it's not notable changes.

https://github.com/reviewdog/reviewdog/actions/runs/9927782041/job/27423172020

```
POST https://api.github.com/repos/reviewdog/action-eclint/dispatches: 404 Not Found []
exit status 1
```

https://github.com/reviewdog/action-eclint is arcived.
Therefore, CI `release` can't call CI `depup` in this repository.
For this reason, I exclude archived repositories from the targets of the API call.