### PR TITLE
Remove original_output from RDJSON(L) output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ...
 
 ### :rotating_light: Breaking changes
+- [#1858](https://github.com/reviewdog/reviewdog/pull/1858) Remove original_output from rdjson/rdjsonl reporters' output
 - ...
 
 ## [v0.20.1] - 2024-07-10

--- a/comment_iowriter.go
+++ b/comment_iowriter.go
@@ -79,6 +79,8 @@ func (cw *RDJSONLCommentWriter) Post(_ context.Context, c *Comment) error {
 			Name: c.ToolName,
 		}
 	}
+	// Remove OriginalOutput. It's used internally and we shouldn't expose it as output.
+	c.Result.Diagnostic.OriginalOutput = ""
 	b, err := protojson.MarshalOptions{
 		UseProtoNames:     true,
 		UseEnumNumbers:    false,
@@ -124,6 +126,8 @@ func (cw *RDJSONCommentWriter) Flush(_ context.Context) error {
 		Diagnostics: make([]*rdf.Diagnostic, 0, len(cw.comments)),
 	}
 	for _, c := range cw.comments {
+		// Remove OriginalOutput. It's used internally and we shouldn't expose it as output.
+		c.Result.Diagnostic.OriginalOutput = ""
 		result.Diagnostics = append(result.Diagnostics, c.Result.Diagnostic)
 	}
 	b, err := protojson.MarshalOptions{

--- a/comment_iowriter_test.go
+++ b/comment_iowriter_test.go
@@ -104,8 +104,9 @@ func TestRDJSONLCommentWriter_Post(t *testing.T) {
 			in: &Comment{
 				Result: &filter.FilteredDiagnostic{
 					Diagnostic: &rdf.Diagnostic{
-						Location: &rdf.Location{Path: "/path/to/file"},
-						Message:  "message",
+						Location:       &rdf.Location{Path: "/path/to/file"},
+						Message:        "message",
+						OriginalOutput: "original output",
 					},
 				},
 				ToolName: "tool name",
@@ -167,8 +168,9 @@ func TestRDJSONCommentWriter_Post(t *testing.T) {
 		{
 			Result: &filter.FilteredDiagnostic{
 				Diagnostic: &rdf.Diagnostic{
-					Location: &rdf.Location{Path: "/path/to/file"},
-					Message:  "message",
+					Location:       &rdf.Location{Path: "/path/to/file"},
+					Message:        "message",
+					OriginalOutput: "original output",
 				},
 			},
 			ToolName: "tool name",


### PR DESCRIPTION
It's used internally and we shouldn't expose it as output.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

