### PR TITLE
Add CI release test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,9 @@ jobs:
 
       # Setup Go for building reviewdog binary.
       - uses: actions/setup-go@v5
+        if: "steps.tag.outputs.value != ''"
         with:
           go-version-file: "go.mod"
-
-      # Test goreleaser if the tag is empty.
-      - name: Test goreleaser
-        uses: goreleaser/goreleaser-action@v6
-        if: "steps.tag.outputs.value == ''"
-        with:
-          version: latest
-          args: check
 
       # Create release.
       - name: Create release with goreleaser

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,0 +1,34 @@
+name: release test
+on:
+  push:
+    branches:
+      - master
+      - release-*
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    paths:
+      - .github/workflows/release_test.yml
+      - '.goreleaser*.yml'
+      - go.mod
+      - go.sum
+
+jobs:
+  release_test:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Setup Go for building reviewdog binary.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Test goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: check


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
   - it's not notable changes.

I want to run `goreleaser check` in PR if there is a difference in `.goreleaser.yml` or `.goreleaser-nightly.yml`.
Therefore, I separate `goreleaser check` from CI `release`.