### PR TITLE
Set version: 2 for .goreleaser.yml

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -1,4 +1,6 @@
 # For nightly release. See .goreleaser.yml for normal release.
+version: 2
+
 project_name: reviewdog
 
 before:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # Document: http://goreleaser.com
 # This config is for normal release. See .goreleaser-nightly.yml for nightly release.
+version: 2
+
 before:
   hooks:
     - go mod download


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
   -  it's not notable changes.

https://github.com/reviewdog/reviewdog/actions/runs/10369567243/job/28705575699

```
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
```


To solve the above problem, I set `version: 2` for `.goreleaser.yml` and `.goreleaser-nightly.yml`.