### PR TITLE
fix: releasing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - master
       - release-*
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   pull_request:
     types:
       - labeled
@@ -45,7 +45,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         if: "steps.tag.outputs.value != ''"
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --release-header .github/goreleaser-header.md
         env:
           # Need to use personal access token instead of default token to

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -5,11 +5,11 @@ on:
       - master
       - release-*
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   pull_request:
     paths:
       - .github/workflows/release_test.yml
-      - '.goreleaser*.yml'
+      - ".goreleaser*.yml"
       - go.mod
       - go.sum
 
@@ -30,5 +30,5 @@ jobs:
       - name: Test goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: check

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -49,4 +49,4 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
release test workflow fails with the latest goreleaser (v2.2.0):

https://github.com/reviewdog/reviewdog/actions/runs/10547764675
<img width="1523" alt="image" src="https://github.com/user-attachments/assets/54115086-1e7e-48bd-99d7-242a52744565">

this pull request fixes this.