### PR TITLE
fix: don't post GitHub comments concurrently from each runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [#1912](https://github.com/reviewdog/reviewdog/pull/1912): fix a bug where GitHub review comments were posted concurrently, causing some comments to be deleted when multiple runners are used ([#1911](https://github.com/reviewdog/reviewdog/pull/1911))
+
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Resolves #1911.

Call the `reviewdog.RunFromResult()` function only once after the results of all the runners are collected.
This prevents the scenario where multiple reviewdog runners list the comments, post their own review comments, **and delete each other's comments**, that is described in #1911.

I tested this locally on a PR. From what I see the linters still run in parallel, but the comments are posted in one go. I placed `log.Println()` lines in the GitHub helpers to verify it.

⚠️ I don't know Go and did this at the best of my capabilities with the help of ChatGPT. I may have not understood all the implications of this change.