### PR TITLE
Add toolchain in scripts/trigger-depup/go.mod

### DIFF
--- a/scripts/trigger-depup/go.mod
+++ b/scripts/trigger-depup/go.mod
@@ -2,6 +2,8 @@ module github.com/reviewdog/reviewdog/scripts/trigger-depup
 
 go 1.21
 
+toolchain go1.21.13
+
 require (
 	github.com/google/go-github/v64 v64.0.0
 	golang.org/x/oauth2 v0.23.0


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.
    - It's not notable changes.

I add a `toolchain` statement to `scripts/trigger-depup/go.mod`.