### PR TITLE
Allowing for Range.End to be Nil for gitlab_mr_discussion

### DIFF
--- a/service/gitlab/gitlab_mr_discussion.go
+++ b/service/gitlab/gitlab_mr_discussion.go
@@ -173,7 +173,7 @@ func listAllMergeRequestDiscussion(cli *gitlab.Client, projectID string, mergeRe
 func buildSuggestions(c *reviewdog.Comment) string {
 	var sb strings.Builder
 	for _, s := range c.Result.Diagnostic.GetSuggestions() {
-		if s.Range == nil || s.Range.Start == nil || s.Range.End == nil {
+		if s.Range == nil || s.Range.Start == nil {
 			continue
 		}
 
@@ -202,7 +202,14 @@ func buildSingleSuggestion(c *reviewdog.Comment, s *rdf.Suggestion) (string, err
 	txt := s.GetText()
 	backticks := commentutil.GetCodeFenceLength(txt)
 
-	lines := strconv.Itoa(int(s.Range.End.Line - s.Range.Start.Line))
+	// Handle the case where Range.End is nil
+	var lines string
+	if s.Range.End != nil {
+		lines = strconv.Itoa(int(s.Range.End.Line - s.Range.Start.Line))
+	} else {
+		lines = "0" // Default to 0 if End is nil
+	}
+
 	sb.Grow(backticks + len("suggestion:-0+\n") + len(lines) + len(txt) + len("\n") + backticks)
 	commentutil.WriteCodeFence(&sb, backticks)
 	sb.WriteString("suggestion:-0+")


### PR DESCRIPTION
- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Not a notable change. 

-- 
Rdjson format supports Range.End to be Nil. In gitlab we were not generating suggestion if the End was Nil. This PR fixes it. 

Note: I am not a pro on Go language, so if there are any updates, please feel free to suggest an improvement. 

