### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ...
 
 ### :bug: Fixes
-- Include stderr in the error message if we run git command
+- ...
 
 ### :rotating_light: Breaking changes
 - ...
+
+## [v0.20.3] - 2024-12-04
+
+### :bug: Fixes
+- [#1977](https://github.com/reviewdog/reviewdog/pull/1977) Include stderr in the error message if we run git command
 
 ## [v0.20.2] - 2024-09-16
 
@@ -284,7 +289,7 @@ $ cd subdir/ && reviewdog -filter-mode=file -fail-on-error -reporter=github-pr-r
 
 See https://github.com/reviewdog/reviewdog/releases for older release note.
 
-[Unreleased]: https://github.com/reviewdog/reviewdog/compare/v0.17.4...HEAD
+[Unreleased]: https://github.com/reviewdog/reviewdog/compare/v0.20.3...HEAD
 [v0.10.0]: https://github.com/reviewdog/reviewdog/compare/v0.9.17...v0.10.0
 [v0.10.1]: https://github.com/reviewdog/reviewdog/compare/v0.10.0...v0.10.1
 [v0.10.2]: https://github.com/reviewdog/reviewdog/compare/v0.10.1...v0.10.2
@@ -309,4 +314,5 @@ See https://github.com/reviewdog/reviewdog/releases for older release note.
 [v0.20.0]: https://github.com/reviewdog/reviewdog/compare/v0.19.0...v0.20.0
 [v0.20.1]: https://github.com/reviewdog/reviewdog/compare/v0.20.0...v0.20.1
 [v0.20.2]: https://github.com/reviewdog/reviewdog/compare/v0.20.1...v0.20.2
+[v0.20.3]: https://github.com/reviewdog/reviewdog/compare/v0.20.2...v0.20.3
 [@haya14busa]: https://github.com/haya14busa


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Since v0.20.3 was released without updating CHANGELOG, I update CHANGELOG.