### PR TITLE
Update fail_on_error to fail_level in workflows

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -207,7 +207,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           filter_mode: nofilter
-          fail_on_error: true
+          fail_level: any
           # workdir: ./_testdata/
 
   misspell:


### PR DESCRIPTION
Not notable change, so no changelog.

`fail_on_error` flag is deprecated: https://github.com/reviewdog/action-staticcheck/pull/68 + https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#rotating_light-deprecation-warnings
