### PR TITLE
github-[pr-][check|annotate]: Do not filter if no PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- [#2026](https://github.com/reviewdog/reviewdog/pull/2026) Add reporter for GitHub annotations `github-annotations`
+- [#2026](https://github.com/reviewdog/reviewdog/pull/2026) Add reporter for GitHub annotations `github-annotations`. Same as `github-pr-annotations` but not restricted to pull requests.
 
 ### :bug: Fixes
 - [#1983](https://github.com/reviewdog/reviewdog/pull/1983) Improve error message for diff command failure by including stderr output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :bug: Fixes
 - [#1983](https://github.com/reviewdog/reviewdog/pull/1983) Improve error message for diff command failure by including stderr output
 - [#1975](https://github.com/reviewdog/reviewdog/pull/1975) Fix for suggestions not including an inserted EOF newline
+- [#2026](https://github.com/reviewdog/reviewdog/pull/2026) Never filter diffs when running `github-[pr-][check|annotate]` on non-PRs
 
 ### :rotating_light: Breaking changes
 - ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
-- ...
+- [#2026](https://github.com/reviewdog/reviewdog/pull/2026) Add reporter for GitHub annotations `github-annotations`
 
 ### :bug: Fixes
 - [#1983](https://github.com/reviewdog/reviewdog/pull/1983) Improve error message for diff command failure by including stderr output

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ by diff.
   * [Reporter: GitHub Checks (-reporter=github-pr-check)](#reporter-github-checks--reportergithub-pr-check)
   * [Reporter: GitHub Checks (-reporter=github-check)](#reporter-github-checks--reportergithub-check)
   * [Reporter: GitHub PullRequest review comment (-reporter=github-pr-review)](#reporter-github-pullrequest-review-comment--reportergithub-pr-review)
+  * [Reporter: GitHub Annotations (-reporter=github-pr-annotations)](#reporter-github-pr-annotations--reportergithub-pr-annotations)
   * [Reporter: GitLab MergeRequest discussions (-reporter=gitlab-mr-discussion)](#reporter-gitlab-mergerequest-discussions--reportergitlab-mr-discussion)
   * [Reporter: GitLab MergeRequest commit (-reporter=gitlab-mr-commit)](#reporter-gitlab-mergerequest-commit--reportergitlab-mr-commit)
   * [Reporter: Bitbucket Code Insights Reports (-reporter=bitbucket-code-report)](#reporter-bitbucket-code-insights-reports--reporterbitbucket-code-report)

--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ by diff.
 - [reviewdog config file](#reviewdog-config-file)
 - [Reporters](#reporters)
   * [Reporter: Local (-reporter=local) [default]](#reporter-local--reporterlocal-default)
-  * [Reporter: GitHub Checks (-reporter=github-pr-check)](#reporter-github-checks--reportergithub-pr-check)
+  * [Reporter: GitHub PR Checks (-reporter=github-pr-check)](#reporter-github-pr-checks--reportergithub-pr-check)
   * [Reporter: GitHub Checks (-reporter=github-check)](#reporter-github-checks--reportergithub-check)
   * [Reporter: GitHub PullRequest review comment (-reporter=github-pr-review)](#reporter-github-pullrequest-review-comment--reportergithub-pr-review)
-  * [Reporter: GitHub Annotations (-reporter=github-pr-annotations)](#reporter-github-pr-annotations--reportergithub-pr-annotations)
+  * [Reporter: GitHub Annotations (-reporter=github-annotations)](#reporter-github-annotations--reportergithub-annotations)
+  * [Reporter: GitHub PR Annotations (-reporter=github-pr-annotations)](#reporter-github-pr-annotations--reportergithub-pr-annotations)
   * [Reporter: GitLab MergeRequest discussions (-reporter=gitlab-mr-discussion)](#reporter-gitlab-mergerequest-discussions--reportergitlab-mr-discussion)
   * [Reporter: GitLab MergeRequest commit (-reporter=gitlab-mr-commit)](#reporter-gitlab-mergerequest-commit--reportergitlab-mr-commit)
   * [Reporter: Bitbucket Code Insights Reports (-reporter=bitbucket-code-report)](#reporter-bitbucket-code-insights-reports--reporterbitbucket-code-report)
@@ -318,6 +319,8 @@ Note that not all reporters provide support for code suggestions.
 | **`local`**                  | NO [1]  |
 | **`github-check`**           | NO [2]  |
 | **`github-pr-check`**        | NO [2]  |
+| **`github-annotations`**     | NO [2]  |
+| **`github-pr-annotations`**  | NO [2]  |
 | **`github-pr-review`**       | OK      |
 | **`gitlab-mr-discussion`**   | OK      |
 | **`gitlab-mr-commit`**       | NO [2]  |
@@ -394,7 +397,7 @@ using diff. You can pass the diff command as `-diff` arg.
 $ golint ./... | reviewdog -f=golint -diff="git diff FETCH_HEAD"
 ```
 
-### Reporter: GitHub Checks (-reporter=github-pr-check)
+### Reporter: GitHub PR Checks (-reporter=github-pr-check)
 
 [![github-pr-check sample annotation with option 1](https://user-images.githubusercontent.com/3797062/64875597-65016f80-d688-11e9-843f-4679fb666f0d.png)](https://github.com/reviewdog/reviewdog/pull/275/files#annotation_6177941961779419)
 [![github-pr-check sample](https://user-images.githubusercontent.com/3797062/40884858-6efd82a0-6756-11e8-9f1a-c6af4f920fb0.png)](https://github.com/reviewdog/reviewdog/pull/131/checks)
@@ -493,9 +496,9 @@ $ export REVIEWDOG_INSECURE_SKIP_VERIFY=true # set this as you need to skip veri
 See [GitHub Actions](#github-actions) section too if you can use GitHub
 Actions. You can also use public reviewdog GitHub Actions.
 
-### Reporter: GitHub PR Annotations (-reporter=github-pr-annotations)
+### Reporter: GitHub Annotations (-reporter=github-annotations)
 
-github-pr-annotations uses the GitHub Actions annotation format to output errors
+`github-annotations` uses the GitHub Actions annotation format to output errors
 and warnings to `stdout` e.g.
 
 ```
@@ -504,6 +507,10 @@ and warnings to `stdout` e.g.
 
 This reporter requires a valid GitHub API token to generate a diff, but will not
 use the token to report errors.
+
+### Reporter: GitHub PR Annotations (-reporter=github-pr-annotations)
+
+Same as `github-annotations` but only works for Pull Requests.
 
 ### Reporter: GitLab MergeRequest discussions (-reporter=gitlab-mr-discussion)
 

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -138,6 +138,12 @@ const (
 		For GitHub Enterprise:
 			$ export GITHUB_API="https://example.githubenterprise.com/api/v3"
 
+	"github-annotations"
+		Report results to stdout in GitHub Actions annotation format.
+
+	"github-pr-annotations"
+		Same as github-annotations reporter but it only supports Pull Requests.
+
 	"gitlab-mr-discussion"
 		Report results to GitLab MergeRequest discussion.
 
@@ -326,7 +332,7 @@ func run(r io.Reader, w io.Writer, opt *option) error {
 		}
 		ds = ghDiffService
 		cs = reviewdog.MultiCommentService(checkService, cs)
-	case "github-pr-annotations":
+	case "github-annotations", "github-pr-annotations":
 		var err error
 		var isPR bool
 		cs, ds, isPR, err = githubActionLogService(ctx, opt)


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Reviewdog currently does not report anything for `github-[pr-][check|annotate]` reporters when triggered by pushing a commit.

Previously, diffs were not filtered when running reviewdog with `github-[pr-][check|annotate]` reporters on a non-PR (e.g. push commit).
https://github.com/reviewdog/reviewdog/blob/1cf12d8c1dbae779542917bbe53945bd510f4f9c/doghouse/server/doghouse.go#L61-L65
This makes sense because when not executed on a PR, the `DiffService` is empty.
https://github.com/reviewdog/reviewdog/blob/7e8096c17b1d9080dd25cc4c616ce690361920de/cmd/reviewdog/main.go#L665-L675
However, https://github.com/reviewdog/reviewdog/commit/5e276abc654a39bc0967cfa06c2de821c1c065b8 changed the behaviour of reviewdog to *always* filter the diffs.

Restore the previous behaviour by setting `opt.filterMode = filter.ModeNoFilter` when running on a non-PR.

I think this might also resolve #1952