### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -1004,7 +1004,7 @@ func newParserFromOpt(opt *option) (parser.Parser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fail to create parser. use either -f or -efm: %w", err)
 	}
-	return p, err
+	return p, nil
 }
 
 func toolName(opt *option) string {


### PR DESCRIPTION

Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.

