### PR TITLE
Revert "Use $default-branch instead of master"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     branches:
-      - $default-branch
+      - master
       - release-*
     tags:
       - "v*.*.*"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,7 +2,7 @@ name: reviewdog
 on:
   push:
     branches:
-      - $default-branch
+      - master
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ name: reviewdog (github-check)
 on:
   push:
     branches:
-      - $default-branch
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
This reverts commit bb8647eb65405d610749c5b4e9b46ba6f0532443.

`#default-branch` doesn't work we expected.
see https://github.com/reviewdog/reviewdog/pull/952#pullrequestreview-666216039

- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

