### PR TITLE
service/github: Fetch diff from base pull request repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :rocket: Enhancements
 - [#2026](https://github.com/reviewdog/reviewdog/pull/2026) Add reporter for GitHub annotations `github-annotations`. Same as `github-pr-annotations` but not restricted to pull requests.
+- [#2131](https://github.com/reviewdog/reviewdog/pull/2131) Fetch GitHub git based diffs using the base pull request repo to allow fetching from private forks in GitHub Actions.
 
 ### :bug: Fixes
 - [#967](https://github.com/reviewdog/reviewdog/pull/967) Fix parsing long lines in diffs #967


### PR DESCRIPTION
Previously, if you tried to fallback to Git based fetching with a private repo fork on GitHub Actions, the command would fail because the automatic token used for GitHub Actions is only scoped to the current repo, not the head repo.

```
reviewdog: fail to get diff: failed to run git fetch: remote: Repository not found.
  fatal: repository 'https://github.com/wlynch/my-private-fork/' not found
```

GitHub forks store all commit data in the same namespace, which allows you to access commit content from PRs / forks from the base repo. This should allow the use of the default GitHub token to fetch the head PR content.


- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

