### PR TITLE
Prevent hang on long stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2257](https://github.com/reviewdog/reviewdog/pull/2257) Use -trimpath flag for reproducible build
 
 ### :bug: Fixes
+- [#2477](https://github.com/reviewdog/reviewdog/pull/2477) Prevent deadlock when a runner outputs large `stderr`.
 
 ### :rotating_light: Breaking changes
 

--- a/project/run.go
+++ b/project/run.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -59,7 +61,7 @@ func RunAndParse(ctx context.Context, conf *Config, runners map[string]bool, def
 		}
 		g.Go(func() error {
 			defer func() { <-semaphore }()
-			diagnostics, err := p.Parse(io.MultiReader(stdout, stderr))
+			diagnostics, err := p.Parse(concurrentMultiReader(stdout, stderr))
 			if err != nil {
 				return err
 			}
@@ -166,4 +168,56 @@ func getRunnerName(key string, runner *Runner) string {
 		return runner.Name
 	}
 	return key
+}
+
+type lockedWriter struct {
+	w  *bufio.Writer
+	mu *sync.Mutex
+}
+
+func (lw *lockedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.w.Write(p)
+}
+
+// We need concurrent Reader to prevent deadlock.
+// If we read stdout and stderr sequentially,
+// 1. huge stderr can block the process
+// 2. stdout doesn't close until the process finishes
+// 3. we can't read stderr until stdout is closed <- deadlock
+func concurrentMultiReader(readers ...io.Reader) io.Reader {
+	pr, pw := io.Pipe()
+
+	var mu sync.Mutex
+	w := &lockedWriter{w: bufio.NewWriter(pw), mu: &mu}
+
+	var g errgroup.Group
+	for _, r := range readers {
+		g.Go(func() error {
+			s := bufio.NewScanner(r)
+			for s.Scan() {
+				line := s.Bytes()
+				if _, err := w.Write(append(line, '\n')); err != nil {
+					return err
+				}
+			}
+			return s.Err()
+		})
+	}
+
+	go func() {
+		err := g.Wait()
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err :=w.w.Flush(); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
+	}()
+
+	return pr
 }

--- a/project/run.go
+++ b/project/run.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -11,7 +10,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -170,17 +168,6 @@ func getRunnerName(key string, runner *Runner) string {
 	return key
 }
 
-type lockedWriter struct {
-	w  *bufio.Writer
-	mu *sync.Mutex
-}
-
-func (lw *lockedWriter) Write(p []byte) (int, error) {
-	lw.mu.Lock()
-	defer lw.mu.Unlock()
-	return lw.w.Write(p)
-}
-
 // We need concurrent Reader to prevent deadlock.
 // If we read stdout and stderr sequentially,
 // 1. huge stderr can block the process
@@ -188,21 +175,18 @@ func (lw *lockedWriter) Write(p []byte) (int, error) {
 // 3. we can't read stderr until stdout is closed <- deadlock
 func concurrentMultiReader(readers ...io.Reader) io.Reader {
 	pr, pw := io.Pipe()
-
-	var mu sync.Mutex
-	w := &lockedWriter{w: bufio.NewWriter(pw), mu: &mu}
+	var bufs []*bytes.Buffer
 
 	var g errgroup.Group
 	for _, r := range readers {
+		b := &bytes.Buffer{}
+		bufs = append(bufs, b)
 		g.Go(func() error {
-			s := bufio.NewScanner(r)
-			for s.Scan() {
-				line := s.Bytes()
-				if _, err := w.Write(append(line, '\n')); err != nil {
-					return err
-				}
+			_, err := io.Copy(b, r)
+			if err != nil {
+				return err
 			}
-			return s.Err()
+			return nil
 		})
 	}
 
@@ -212,9 +196,11 @@ func concurrentMultiReader(readers ...io.Reader) io.Reader {
 			_ = pw.CloseWithError(err)
 			return
 		}
-		if err :=w.w.Flush(); err != nil {
-			_ = pw.CloseWithError(err)
-			return
+		for _, b := range bufs {
+			if _, err := io.Copy(pw, b); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
 		}
 		_ = pw.Close()
 	}()

--- a/project/run_test.go
+++ b/project/run_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/reviewdog/reviewdog"
 	"github.com/reviewdog/reviewdog/filter"
@@ -292,6 +293,42 @@ func TestRun(t *testing.T) {
 		}
 		if err := Run(ctx, conf, map[string]bool{"hoge": true}, cs, ds, false, filter.ModeAdded, reviewdog.FailLevelNone); err == nil {
 			t.Error("got no error but want runner not found error")
+		}
+	})
+
+
+	// #1934
+	t.Run("big stderr",  func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("requires POSIX shell utilities")
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		conf := &Config{
+			Runner: map[string]*Runner{
+				"test": {
+					Cmd:         "yes x | head -c 131072 >&2; echo 'file:1:1:message'",
+					Errorformat: []string{`%f:%l:%c:%m`},
+				},
+			},
+		}
+
+		results, err := RunAndParse(ctx, conf, nil, "", false)
+		if err != nil {
+			t.Fatalf("RunAndParse failed: %v", err)
+		}
+
+		result, err := results.Load("test")
+		if err != nil {
+			t.Fatalf("failed to load result: %v", err)
+		}
+		if result.CmdErr != nil {
+			t.Fatalf("unexpected command error: %v", result.CmdErr)
+		}
+		if len(result.Diagnostics) != 1 {
+			t.Fatalf("got %d diagnostics, want 1", len(result.Diagnostics))
 		}
 	})
 }

--- a/project/run_test.go
+++ b/project/run_test.go
@@ -296,9 +296,8 @@ func TestRun(t *testing.T) {
 		}
 	})
 
-
 	// #1934
-	t.Run("big stderr",  func(t *testing.T) {
+	t.Run("big stderr", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("requires POSIX shell utilities")
 		}


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Fixes #1934

**Caution**
This change can cause unbounded memory use if stdout / stderr are very long.
If you worry OOM, I suggest following approaches:
- Option 1: write stdout / stderr to temporal file.
- Option 2: throw error if stdout / stderr exceed a specific limit (64KB? 32MB? 1GB? configurable?)

I'll implement one that maintainers prefer.

**Note**
I've tried line-by-line concurrent read. But maybe it's not good for rsjson I guess, though it passes existing test cases. https://github.com/reviewdog/reviewdog/pull/2477/commits/ade85f44417bf5b958890605f34ebeee3d0d162d