### PR TITLE
Drop support of windows/arm

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -30,6 +30,9 @@ builds:
       - amd64
       - arm
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm
 
 archives:
   - id: main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,9 @@ builds:
       - amd64
       - arm
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm
 
 archives:
   - id: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :rocket: Enhancements
 - [#2257](https://github.com/reviewdog/reviewdog/pull/2257) Use -trimpath flag for reproducible build
+- [#2513](https://github.com/reviewdog/reviewdog/pull/2513) Drop support of windows/arm
 
 ### :bug: Fixes
 


### PR DESCRIPTION
goreleaser is failing to build the binaries.

```plain
% goreleaser build --clean --snapshot
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=f23f7d7768dbb07529989612bc535b57019b7034 branch=master current_tag=v0.21.0 previous_tag=v0.20.3 dirty=false
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    ⨯ broken target, use at your own risk            target=windows_arm_6
    • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
  • snapshotting
    • building snapshot...                           version=v0.21.0-next
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/reviewdog_darwin_amd64_v1/reviewdog
    • building                                       binary=dist/reviewdog_linux_386_sse2/reviewdog
    • building                                       binary=dist/reviewdog_linux_amd64_v1/reviewdog
    • building                                       binary=dist/reviewdog_darwin_arm64_v8.0/reviewdog
    • building                                       binary=dist/reviewdog_windows_arm64_v8.0/reviewdog.exe
    • building                                       binary=dist/reviewdog_windows_386_sse2/reviewdog.exe
    • building                                       binary=dist/reviewdog_linux_arm64_v8.0/reviewdog
    • building                                       binary=dist/reviewdog_windows_arm_6/reviewdog.exe
    • building                                       binary=dist/reviewdog_linux_arm_6/reviewdog
    • building                                       binary=dist/reviewdog_windows_amd64_v1/reviewdog.exe
      • took: 45s
  ⨯ build failed after 46s                          
    error=
    │ build failed: exit status 2: go: unsupported GOOS/GOARCH pair windows/arm
    target=windows_arm_6
```

This is because the windows/arm port is no longer supported starting from Go 1.26.

> As [announced](https://go.dev/doc/go1.25#windows) in the Go 1.25 release notes, the [broken](https://go.dev/doc/go1.24#windows) 32-bit windows/arm port (GOOS=windows GOARCH=arm) has been removed.
>
> https://go.dev/doc/go1.26#windows

I fixed it by excluding windows/arm from the build target.
`goreleaser build` is now happy:

```plain
% goreleaser build --clean --snapshot
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=f23f7d7768dbb07529989612bc535b57019b7034 branch=master current_tag=v0.21.0 previous_tag=v0.20.3 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
  • snapshotting
    • building snapshot...                           version=v0.21.0-next
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/reviewdog_linux_386_sse2/reviewdog
    • building                                       binary=dist/reviewdog_windows_386_sse2/reviewdog.exe
    • building                                       binary=dist/reviewdog_linux_arm_6/reviewdog
    • building                                       binary=dist/reviewdog_darwin_amd64_v1/reviewdog
    • building                                       binary=dist/reviewdog_darwin_arm64_v8.0/reviewdog
    • building                                       binary=dist/reviewdog_windows_amd64_v1/reviewdog.exe
    • building                                       binary=dist/reviewdog_linux_amd64_v1/reviewdog
    • building                                       binary=dist/reviewdog_windows_arm64_v8.0/reviewdog.exe
    • building                                       binary=dist/reviewdog_linux_arm64_v8.0/reviewdog
  • writing artifacts metadata
  • build succeeded after 2s
  • thanks for using GoReleaser!
```


- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

