### PR TITLE
service/gitlab: auto-resolve outdated MR discussions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :rocket: Enhancements
 - [#2257](https://github.com/reviewdog/reviewdog/pull/2257) Use -trimpath flag for reproducible build
+- Update `gitlab-mr-discussion` reporter to embed a fingerprint meta-comment in each posted note and automatically resolve previously-posted discussions whose diagnostic is no longer reported (fixes [#1150](https://github.com/reviewdog/reviewdog/issues/1150)).
 
 ### :bug: Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :rocket: Enhancements
 - [#2257](https://github.com/reviewdog/reviewdog/pull/2257) Use -trimpath flag for reproducible build
 - [#2513](https://github.com/reviewdog/reviewdog/pull/2513) Drop support of windows/arm
+- [#2543](https://github.com/reviewdog/reviewdog/pull/2543) Update `gitlab-mr-discussion` reporter to embed a fingerprint meta-comment in each posted note and automatically resolve previously-posted discussions whose diagnostic is no longer reported (fixes [#1150](https://github.com/reviewdog/reviewdog/issues/1150)).
 
 ### :bug: Fixes
 

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -365,7 +365,7 @@ func run(r io.Reader, w io.Writer, opt *option) error {
 			return nil
 		}
 
-		gc := gitlabservice.NewGitLabMergeRequestDiscussionCommenter(cli, build.Owner, build.Repo, build.PullRequest, build.SHA)
+		gc := gitlabservice.NewGitLabMergeRequestDiscussionCommenter(cli, build.Owner, build.Repo, build.PullRequest, build.SHA, toolName(opt))
 		cs = reviewdog.MultiCommentService(gc, cs)
 		ds = gitlabservice.NewGitLabMergeRequestDiff(cli, build.Owner, build.Repo, build.PullRequest, build.SHA)
 	case "gitlab-mr-commit":

--- a/service/gitlab/gitlab_mr_discussion.go
+++ b/service/gitlab/gitlab_mr_discussion.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/reviewdog/reviewdog"
 	"github.com/reviewdog/reviewdog/proto/rdf"
 	"github.com/reviewdog/reviewdog/service/commentutil"
+	"github.com/reviewdog/reviewdog/service/serviceutil"
 )
 
 const (
@@ -31,19 +33,28 @@ type MergeRequestDiscussionCommenter struct {
 	pr       int
 	sha      string
 	projects string
+	toolName string
 
 	muComments   sync.Mutex
 	postComments []*reviewdog.Comment
+
+	postedcs commentutil.PostedComments
+	// outdatedDiscussions holds resolvable discussions previously posted by
+	// reviewdog that are candidates for auto-resolve if no longer reported.
+	// Keyed by fingerprint; value is a slice so fingerprint collisions across
+	// discussions do not silently drop entries.
+	outdatedDiscussions map[string][]string // fingerprint -> []discussionID
 }
 
 // NewGitLabMergeRequestDiscussionCommenter returns a new MergeRequestDiscussionCommenter service.
 // MergeRequestDiscussionCommenter service needs git command in $PATH.
-func NewGitLabMergeRequestDiscussionCommenter(cli *gitlab.Client, owner, repo string, pr int, sha string) *MergeRequestDiscussionCommenter {
+func NewGitLabMergeRequestDiscussionCommenter(cli *gitlab.Client, owner, repo string, pr int, sha, toolName string) *MergeRequestDiscussionCommenter {
 	return &MergeRequestDiscussionCommenter{
 		cli:      cli,
 		pr:       pr,
 		sha:      sha,
 		projects: owner + "/" + repo,
+		toolName: toolName,
 	}
 }
 
@@ -63,22 +74,31 @@ func (g *MergeRequestDiscussionCommenter) Flush(ctx context.Context) error {
 	g.muComments.Lock()
 	defer g.muComments.Unlock()
 	defer func() { g.postComments = nil }()
-	postedcs, err := g.createPostedComments()
-	if err != nil {
+	if err := g.setPostedComments(); err != nil {
 		return fmt.Errorf("failed to create posted comments: %w", err)
 	}
-	return g.postCommentsForEach(ctx, postedcs)
+	if err := g.postCommentsForEach(ctx); err != nil {
+		return err
+	}
+	return g.resolveOutdatedDiscussions(ctx)
 }
 
-func (g *MergeRequestDiscussionCommenter) createPostedComments() (commentutil.PostedComments, error) {
-	postedcs := make(commentutil.PostedComments)
+// setPostedComments lists existing merge request discussions and records the
+// ones previously posted by reviewdog (identified by the embedded meta
+// comment). Resolvable, unresolved discussions authored by this tool are
+// tracked as potentially outdated and will be resolved by
+// resolveOutdatedDiscussions unless the diagnostic is reported again in this
+// run.
+func (g *MergeRequestDiscussionCommenter) setPostedComments() error {
+	g.postedcs = make(commentutil.PostedComments)
+	g.outdatedDiscussions = make(map[string][]string)
 	discussions, err := listAllMergeRequestDiscussion(g.cli, g.projects, g.pr, &gitlab.ListMergeRequestDiscussionsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: 100,
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list all merge request discussions: %w", err)
+		return fmt.Errorf("failed to list all merge request discussions: %w", err)
 	}
 	for _, d := range discussions {
 		for _, note := range d.Notes {
@@ -86,13 +106,28 @@ func (g *MergeRequestDiscussionCommenter) createPostedComments() (commentutil.Po
 			if pos == nil || pos.NewPath == "" || pos.NewLine == 0 || note.Body == "" {
 				continue
 			}
-			postedcs.AddPostedComment(pos.NewPath, int(pos.NewLine), note.Body)
+			if meta := serviceutil.ExtractMetaComment(note.Body); meta != nil {
+				g.postedcs.AddPostedComment(pos.NewPath, int(pos.NewLine), meta.GetFingerprint())
+				// Only track notes authored by this tool. A non-empty toolName
+				// is required so that meta comments with an unset SourceName
+				// are never auto-resolved across unrelated tools.
+				if g.toolName != "" && meta.GetSourceName() == g.toolName && note.Resolvable && !note.Resolved {
+					fp := meta.GetFingerprint()
+					g.outdatedDiscussions[fp] = append(g.outdatedDiscussions[fp], d.ID)
+				}
+				continue
+			}
+			// Back-compat: notes posted before meta comments were added are
+			// matched by raw body text to avoid duplicate posts. These legacy
+			// discussions cannot be auto-resolved (no fingerprint) and will
+			// need to be resolved manually.
+			g.postedcs.AddPostedComment(pos.NewPath, int(pos.NewLine), note.Body)
 		}
 	}
-	return postedcs, nil
+	return nil
 }
 
-func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Context, postedcs commentutil.PostedComments) error {
+func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Context) error {
 	mr, _, err := g.cli.MergeRequests.GetMergeRequest(g.projects, int64(g.pr), nil, gitlab.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to get merge request: %w", err)
@@ -107,15 +142,29 @@ func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Contex
 		c := c
 		loc := c.Result.Diagnostic.GetLocation()
 		lnum := int(loc.GetRange().GetStart().GetLine())
-		body := commentutil.MarkdownComment(c)
-
-		if suggestion := buildSuggestions(c); suggestion != "" {
-			body = body + "\n\n" + suggestion
-		}
-
-		if !c.Result.InDiffFile || lnum == 0 || postedcs.IsPosted(c, lnum, body) {
+		if !c.Result.InDiffFile || lnum == 0 {
 			continue
 		}
+		fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
+		if err != nil {
+			return err
+		}
+		if g.postedcs.IsPosted(c, lnum, fprint) {
+			// Still reported — not outdated.
+			delete(g.outdatedDiscussions, fprint)
+			continue
+		}
+		legacyBody := commentutil.MarkdownComment(c)
+		if suggestion := buildSuggestions(c); suggestion != "" {
+			legacyBody = legacyBody + "\n\n" + suggestion
+		}
+		// Back-compat: notes posted before meta comments were introduced are
+		// indexed by raw body text in postedcs. Skip re-posting if the legacy
+		// body matches. Legacy notes cannot be auto-resolved.
+		if g.postedcs.IsPosted(c, lnum, legacyBody) {
+			continue
+		}
+		body := legacyBody + fmt.Sprintf("\n%s\n", serviceutil.BuildMetaComment(fprint, g.toolName))
 		eg.Go(func() error {
 			pos := &gitlab.PositionOptions{
 				StartSHA:     gitlab.Ptr(targetBranch.Commit.ID),
@@ -141,6 +190,44 @@ func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Contex
 		})
 	}
 	return eg.Wait()
+}
+
+// resolveOutdatedDiscussions marks previously-posted reviewdog discussions as
+// resolved when the corresponding diagnostic is no longer reported in the
+// current run. This keeps a MR review clean as fixes land.
+//
+// All resolve attempts run concurrently; every failure is surfaced via
+// errors.Join so operators see the full picture instead of only the first
+// error.
+func (g *MergeRequestDiscussionCommenter) resolveOutdatedDiscussions(ctx context.Context) error {
+	if g.toolName == "" || len(g.outdatedDiscussions) == 0 {
+		return nil
+	}
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+	for _, ids := range g.outdatedDiscussions {
+		for _, id := range ids {
+			wg.Add(1)
+			go func(discussionID string) {
+				defer wg.Done()
+				_, _, err := g.cli.Discussions.ResolveMergeRequestDiscussion(
+					g.projects, int64(g.pr), discussionID,
+					&gitlab.ResolveMergeRequestDiscussionOptions{Resolved: gitlab.Ptr(true)},
+					gitlab.WithContext(ctx),
+				)
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("failed to resolve merge request discussion (id=%s): %w", discussionID, err))
+					mu.Unlock()
+				}
+			}(id)
+		}
+	}
+	wg.Wait()
+	return errors.Join(errs...)
 }
 
 func listAllMergeRequestDiscussion(cli *gitlab.Client, projectID string, mergeRequest int, opts *gitlab.ListMergeRequestDiscussionsOptions) ([]*gitlab.Discussion, error) {

--- a/service/gitlab/gitlab_mr_discussion.go
+++ b/service/gitlab/gitlab_mr_discussion.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/reviewdog/reviewdog"
 	"github.com/reviewdog/reviewdog/proto/rdf"
 	"github.com/reviewdog/reviewdog/service/commentutil"
+	"github.com/reviewdog/reviewdog/service/serviceutil"
 )
 
 const (
@@ -31,9 +33,17 @@ type MergeRequestDiscussionCommenter struct {
 	pr       int
 	sha      string
 	projects string
+	toolName string
 
 	muComments   sync.Mutex
 	postComments []*reviewdog.Comment
+
+	postedcs commentutil.PostedComments
+	// outdatedDiscussions holds resolvable discussions previously posted by
+	// reviewdog that are candidates for auto-resolve if no longer reported.
+	// Keyed by fingerprint; value is a slice so fingerprint collisions across
+	// discussions do not silently drop entries.
+	outdatedDiscussions map[string][]string // fingerprint -> []discussionID
 }
 
 // NewGitLabMergeRequestDiscussionCommenter returns a new MergeRequestDiscussionCommenter service.
@@ -45,6 +55,12 @@ func NewGitLabMergeRequestDiscussionCommenter(cli *gitlab.Client, owner, repo st
 		sha:      sha,
 		projects: owner + "/" + repo,
 	}
+}
+
+// SetTool sets the tool name used to author meta comments and gate
+// auto-resolve to discussions previously posted by this tool.
+func (g *MergeRequestDiscussionCommenter) SetTool(toolName string, _ string) {
+	g.toolName = toolName
 }
 
 // Post accepts a comment and holds it. Flush method actually posts comments to
@@ -63,22 +79,31 @@ func (g *MergeRequestDiscussionCommenter) Flush(ctx context.Context) error {
 	g.muComments.Lock()
 	defer g.muComments.Unlock()
 	defer func() { g.postComments = nil }()
-	postedcs, err := g.createPostedComments()
-	if err != nil {
+	if err := g.setPostedComments(); err != nil {
 		return fmt.Errorf("failed to create posted comments: %w", err)
 	}
-	return g.postCommentsForEach(ctx, postedcs)
+	if err := g.postCommentsForEach(ctx); err != nil {
+		return err
+	}
+	return g.resolveOutdatedDiscussions(ctx)
 }
 
-func (g *MergeRequestDiscussionCommenter) createPostedComments() (commentutil.PostedComments, error) {
-	postedcs := make(commentutil.PostedComments)
+// setPostedComments lists existing merge request discussions and records the
+// ones previously posted by reviewdog (identified by the embedded meta
+// comment). Resolvable, unresolved discussions authored by this tool are
+// tracked as potentially outdated and will be resolved by
+// resolveOutdatedDiscussions unless the diagnostic is reported again in this
+// run.
+func (g *MergeRequestDiscussionCommenter) setPostedComments() error {
+	g.postedcs = make(commentutil.PostedComments)
+	g.outdatedDiscussions = make(map[string][]string)
 	discussions, err := listAllMergeRequestDiscussion(g.cli, g.projects, g.pr, &gitlab.ListMergeRequestDiscussionsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: 100,
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list all merge request discussions: %w", err)
+		return fmt.Errorf("failed to list all merge request discussions: %w", err)
 	}
 	for _, d := range discussions {
 		for _, note := range d.Notes {
@@ -86,13 +111,21 @@ func (g *MergeRequestDiscussionCommenter) createPostedComments() (commentutil.Po
 			if pos == nil || pos.NewPath == "" || pos.NewLine == 0 || note.Body == "" {
 				continue
 			}
-			postedcs.AddPostedComment(pos.NewPath, int(pos.NewLine), note.Body)
+			meta := serviceutil.ExtractMetaComment(note.Body)
+			if meta == nil {
+				continue
+			}
+			g.postedcs.AddPostedComment(pos.NewPath, int(pos.NewLine), meta.GetFingerprint())
+			if g.toolName != "" && meta.GetSourceName() == g.toolName && note.Resolvable && !note.Resolved {
+				fp := meta.GetFingerprint()
+				g.outdatedDiscussions[fp] = append(g.outdatedDiscussions[fp], d.ID)
+			}
 		}
 	}
-	return postedcs, nil
+	return nil
 }
 
-func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Context, postedcs commentutil.PostedComments) error {
+func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Context) error {
 	mr, _, err := g.cli.MergeRequests.GetMergeRequest(g.projects, int64(g.pr), nil, gitlab.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("failed to get merge request: %w", err)
@@ -107,15 +140,22 @@ func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Contex
 		c := c
 		loc := c.Result.Diagnostic.GetLocation()
 		lnum := int(loc.GetRange().GetStart().GetLine())
+		if !c.Result.InDiffFile || lnum == 0 {
+			continue
+		}
+		fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
+		if err != nil {
+			return err
+		}
+		if g.postedcs.IsPosted(c, lnum, fprint) {
+			delete(g.outdatedDiscussions, fprint)
+			continue
+		}
 		body := commentutil.MarkdownComment(c)
-
 		if suggestion := buildSuggestions(c); suggestion != "" {
 			body = body + "\n\n" + suggestion
 		}
-
-		if !c.Result.InDiffFile || lnum == 0 || postedcs.IsPosted(c, lnum, body) {
-			continue
-		}
+		body += fmt.Sprintf("\n%s\n", serviceutil.BuildMetaComment(fprint, g.toolName))
 		eg.Go(func() error {
 			pos := &gitlab.PositionOptions{
 				StartSHA:     gitlab.Ptr(targetBranch.Commit.ID),
@@ -141,6 +181,44 @@ func (g *MergeRequestDiscussionCommenter) postCommentsForEach(ctx context.Contex
 		})
 	}
 	return eg.Wait()
+}
+
+// resolveOutdatedDiscussions marks previously-posted reviewdog discussions as
+// resolved when the corresponding diagnostic is no longer reported in the
+// current run. This keeps a MR review clean as fixes land.
+//
+// All resolve attempts run concurrently; every failure is surfaced via
+// errors.Join so operators see the full picture instead of only the first
+// error.
+func (g *MergeRequestDiscussionCommenter) resolveOutdatedDiscussions(ctx context.Context) error {
+	if g.toolName == "" || len(g.outdatedDiscussions) == 0 {
+		return nil
+	}
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+	for _, ids := range g.outdatedDiscussions {
+		for _, id := range ids {
+			wg.Add(1)
+			go func(discussionID string) {
+				defer wg.Done()
+				_, _, err := g.cli.Discussions.ResolveMergeRequestDiscussion(
+					g.projects, int64(g.pr), discussionID,
+					&gitlab.ResolveMergeRequestDiscussionOptions{Resolved: gitlab.Ptr(true)},
+					gitlab.WithContext(ctx),
+				)
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("failed to resolve merge request discussion (id=%s): %w", discussionID, err))
+					mu.Unlock()
+				}
+			}(id)
+		}
+	}
+	wg.Wait()
+	return errors.Join(errs...)
 }
 
 func listAllMergeRequestDiscussion(cli *gitlab.Client, projectID string, mergeRequest int, opts *gitlab.ListMergeRequestDiscussionsOptions) ([]*gitlab.Discussion, error) {

--- a/service/gitlab/gitlab_mr_discussion_test.go
+++ b/service/gitlab/gitlab_mr_discussion_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -15,8 +16,34 @@ import (
 	"github.com/reviewdog/reviewdog/filter"
 	"github.com/reviewdog/reviewdog/proto/rdf"
 	"github.com/reviewdog/reviewdog/service/commentutil"
+	"github.com/reviewdog/reviewdog/service/serviceutil"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
+
+// metaBody returns the body that reviewdog would post for the given comment.
+// It matches the format produced by postCommentsForEach.
+func metaBody(t *testing.T, c *reviewdog.Comment, toolName string) string {
+	t.Helper()
+	fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := commentutil.MarkdownComment(c)
+	if suggestion := buildSuggestions(c); suggestion != "" {
+		body += "\n\n" + suggestion
+	}
+	body += "\n" + serviceutil.BuildMetaComment(fprint, toolName) + "\n"
+	return body
+}
+
+func metaBodyForNote(t *testing.T, c *reviewdog.Comment, toolName string) string {
+	t.Helper()
+	fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return commentutil.MarkdownComment(c) + "\n" + serviceutil.BuildMetaComment(fprint, toolName) + "\n"
+}
 
 func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.T) {
 	cwd, _ := os.Getwd()
@@ -170,9 +197,11 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			default:
 				dls := []*gitlab.Discussion{
 					{
+						ID: "already-1",
 						Notes: []*gitlab.Note{
 							{
-								Body: commentutil.MarkdownComment(alreadyCommented1),
+								Body:       metaBodyForNote(t, alreadyCommented1, "tool-name"),
+								Resolvable: true,
 								Position: &gitlab.NotePosition{
 									NewPath: alreadyCommented1.Result.Diagnostic.GetLocation().GetPath(),
 									NewLine: int64(alreadyCommented1.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine()),
@@ -195,9 +224,11 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			case "2":
 				dls := []*gitlab.Discussion{
 					{
+						ID: "already-2",
 						Notes: []*gitlab.Note{
 							{
-								Body: commentutil.MarkdownComment(alreadyCommented2),
+								Body:       metaBodyForNote(t, alreadyCommented2, "tool-name"),
+								Resolvable: true,
 								Position: &gitlab.NotePosition{
 									NewPath: alreadyCommented2.Result.Diagnostic.GetLocation().GetPath(),
 									NewLine: int64(alreadyCommented2.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine()),
@@ -220,7 +251,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			switch *got.Position.NewPath {
 			case "file.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment1)),
+					Body: gitlab.Ptr(metaBody(t, newComment1, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -235,7 +266,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				}
 			case "file2.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment2)),
+					Body: gitlab.Ptr(metaBody(t, newComment2, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -250,7 +281,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				}
 			case "new_file.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment3)),
+					Body: gitlab.Ptr(metaBody(t, newComment3, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -266,11 +297,8 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 					t.Error(diff)
 				}
 			case "file3.go":
-				suggestions := buildSuggestions(newCommentWithSuggestion)
-				bodyExpected := commentutil.MarkdownComment(newCommentWithSuggestion) + "\n\n" + suggestions
-
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(bodyExpected),
+					Body: gitlab.Ptr(metaBody(t, newCommentWithSuggestion, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -314,7 +342,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 		t.Fatal(err)
 	}
 
-	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha")
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha", "tool-name")
 
 	for _, c := range comments {
 		if err := g.Post(context.Background(), c); err != nil {
@@ -326,6 +354,430 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 	}
 	if postCalled != wantPostCalled {
 		t.Errorf("%d discussions posted, but want %d", postCalled, wantPostCalled)
+	}
+}
+
+func TestGitLabMergeRequestDiscussionCommenter_Flush_resolvesOutdatedDiscussions(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	// Diagnostic that WILL be reported again this run — must not be resolved.
+	stillReported := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 1}},
+				},
+				Message: "still reported",
+			},
+			InDiffFile: true,
+		},
+	}
+	// Diagnostic that was previously posted but is NOT reported this run —
+	// its discussion should be resolved.
+	fixed := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 2}},
+				},
+				Message: "fixed in new run",
+			},
+			InDiffFile: true,
+		},
+	}
+	// A previously-posted comment from a DIFFERENT tool must not be resolved
+	// even if not reported this run.
+	otherTool := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 3}},
+				},
+				Message: "from another tool",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	var resolved sync.Map
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			// Accept the POST for stillReported? It won't POST since it's already posted.
+			// If any unexpected POST happens, record it.
+			if r.Method == http.MethodPost {
+				t.Errorf("unexpected discussion create: %v", r.URL)
+				return
+			}
+			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
+			return
+		}
+		dls := []*gitlab.Discussion{
+			{
+				ID: "disc-still-reported",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, stillReported, "tool-name"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 1,
+					},
+				}},
+			},
+			{
+				ID: "disc-fixed",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, fixed, "tool-name"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 2,
+					},
+				}},
+			},
+			{
+				ID: "disc-already-resolved",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, fixed, "tool-name"),
+					Resolvable: true,
+					Resolved:   true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 9,
+					},
+				}},
+			},
+			{
+				ID: "disc-other-tool",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, otherTool, "different-tool"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 3,
+					},
+				}},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(dls); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// Resolve endpoint: PUT /projects/:id/merge_requests/:mr/discussions/:discussion_id
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("unexpected method on resolve: %v %v", r.Method, r.URL)
+			return
+		}
+		// URL form: .../discussions/<id>
+		parts := strings.Split(r.URL.Path, "/")
+		id := parts[len(parts)-1]
+		if r.URL.Query().Get("resolved") != "true" {
+			// client-go sends as JSON body, not query; accept either.
+			var opts gitlab.ResolveMergeRequestDiscussionOptions
+			_ = json.NewDecoder(r.Body).Decode(&opts)
+			if opts.Resolved == nil || !*opts.Resolved {
+				t.Errorf("expected resolve=true, got %+v", opts)
+			}
+		}
+		resolved.Store(id, true)
+		if err := json.NewEncoder(w).Encode(gitlab.Discussion{ID: id}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha", "tool-name")
+	// Only report the stillReported diagnostic — fixed/otherTool are absent this run.
+	if err := g.Post(context.Background(), stillReported); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if _, ok := resolved.Load("disc-fixed"); !ok {
+		t.Errorf("expected disc-fixed to be resolved")
+	}
+	if _, ok := resolved.Load("disc-still-reported"); ok {
+		t.Errorf("disc-still-reported must NOT be resolved (diagnostic is still reported)")
+	}
+	if _, ok := resolved.Load("disc-other-tool"); ok {
+		t.Errorf("disc-other-tool must NOT be resolved (different tool)")
+	}
+	if _, ok := resolved.Load("disc-already-resolved"); ok {
+		t.Errorf("disc-already-resolved must NOT be re-resolved")
+	}
+}
+
+// TestGitLabMergeRequestDiscussionCommenter_Flush_skipsUnresolvableAndLegacy
+// verifies that discussions without a resolvable note (GitLab returns
+// Resolvable=false for some thread kinds) and legacy reviewdog notes without
+// an embedded meta comment are never passed to the resolve endpoint, even when
+// the diagnostic is no longer reported this run.
+func TestGitLabMergeRequestDiscussionCommenter_Flush_skipsUnresolvableAndLegacy(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	legacyComment := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 5}},
+				},
+				Message: "legacy note without meta",
+			},
+			InDiffFile: true,
+		},
+	}
+	unresolvable := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 6}},
+				},
+				Message: "unresolvable thread",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			dls := []*gitlab.Discussion{
+				{
+					ID: "disc-legacy",
+					Notes: []*gitlab.Note{{
+						Body:       commentutil.MarkdownComment(legacyComment),
+						Resolvable: true,
+						Position: &gitlab.NotePosition{
+							NewPath: "file.go",
+							NewLine: 5,
+						},
+					}},
+				},
+				{
+					ID: "disc-unresolvable",
+					Notes: []*gitlab.Note{{
+						Body:       metaBodyForNote(t, unresolvable, "tool-name"),
+						Resolvable: false,
+						Position: &gitlab.NotePosition{
+							NewPath: "file.go",
+							NewLine: 6,
+						},
+					}},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(dls); err != nil {
+				t.Fatal(err)
+			}
+		case http.MethodPost:
+			// Legacy comment must be recognized as already-posted.
+			got := new(gitlab.CreateMergeRequestDiscussionOptions)
+			_ = json.NewDecoder(r.Body).Decode(got)
+			t.Errorf("unexpected discussion POST: %#v", got)
+		default:
+			t.Errorf("unexpected method: %v %v", r.Method, r.URL)
+		}
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected resolve call: %v %v", r.Method, r.URL)
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha", "tool-name")
+	// Re-report the legacy diagnostic so it is matched as already-posted.
+	// Do NOT re-report `unresolvable` — this would normally trigger a resolve,
+	// but Resolvable=false must prevent that.
+	if err := g.Post(context.Background(), legacyComment); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}
+
+// TestGitLabMergeRequestDiscussionCommenter_Flush_propagatesResolveError
+// ensures a failing resolve surfaces as a Flush error rather than being
+// silently swallowed.
+func TestGitLabMergeRequestDiscussionCommenter_Flush_propagatesResolveError(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	fixed := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 2}},
+				},
+				Message: "fixed in new run",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %v", r.Method)
+			return
+		}
+		dls := []*gitlab.Discussion{{
+			ID: "disc-fixed",
+			Notes: []*gitlab.Note{{
+				Body:       metaBodyForNote(t, fixed, "tool-name"),
+				Resolvable: true,
+				Position: &gitlab.NotePosition{
+					NewPath: "file.go",
+					NewLine: 2,
+				},
+			}},
+		}}
+		_ = json.NewEncoder(w).Encode(dls)
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/disc-fixed", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha", "tool-name")
+	// Do not re-post `fixed` — it becomes outdated and triggers a resolve,
+	// which the mock server rejects with 500.
+	err = g.Flush(context.Background())
+	if err == nil {
+		t.Fatalf("expected Flush error, got nil")
+	}
+	if !strings.Contains(err.Error(), "disc-fixed") {
+		t.Errorf("expected error to reference discussion id, got: %v", err)
+	}
+}
+
+// TestGitLabMergeRequestDiscussionCommenter_Flush_paginatedOutdated confirms
+// that outdated discussions appearing on page 2+ of the discussion listing are
+// still picked up for auto-resolve.
+func TestGitLabMergeRequestDiscussionCommenter_Flush_paginatedOutdated(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	fixed := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 7}},
+				},
+				Message: "fixed on page 2",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	var resolved sync.Map
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %v", r.Method)
+			return
+		}
+		switch r.URL.Query().Get("page") {
+		default:
+			w.Header().Add("X-Next-Page", "2")
+			_ = json.NewEncoder(w).Encode([]*gitlab.Discussion{})
+		case "2":
+			dls := []*gitlab.Discussion{{
+				ID: "disc-page2-fixed",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, fixed, "tool-name"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 7,
+					},
+				}},
+			}}
+			_ = json.NewEncoder(w).Encode(dls)
+		}
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		resolved.Store(parts[len(parts)-1], true)
+		_ = json.NewEncoder(w).Encode(gitlab.Discussion{})
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha", "tool-name")
+	if err := g.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if _, ok := resolved.Load("disc-page2-fixed"); !ok {
+		t.Errorf("expected disc-page2-fixed (page 2) to be resolved")
 	}
 }
 

--- a/service/gitlab/gitlab_mr_discussion_test.go
+++ b/service/gitlab/gitlab_mr_discussion_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -15,8 +16,34 @@ import (
 	"github.com/reviewdog/reviewdog/filter"
 	"github.com/reviewdog/reviewdog/proto/rdf"
 	"github.com/reviewdog/reviewdog/service/commentutil"
+	"github.com/reviewdog/reviewdog/service/serviceutil"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
+
+// metaBody returns the body that reviewdog would post for the given comment.
+// It matches the format produced by postCommentsForEach.
+func metaBody(t *testing.T, c *reviewdog.Comment, toolName string) string {
+	t.Helper()
+	fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := commentutil.MarkdownComment(c)
+	if suggestion := buildSuggestions(c); suggestion != "" {
+		body += "\n\n" + suggestion
+	}
+	body += "\n" + serviceutil.BuildMetaComment(fprint, toolName) + "\n"
+	return body
+}
+
+func metaBodyForNote(t *testing.T, c *reviewdog.Comment, toolName string) string {
+	t.Helper()
+	fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return commentutil.MarkdownComment(c) + "\n" + serviceutil.BuildMetaComment(fprint, toolName) + "\n"
+}
 
 func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.T) {
 	cwd, _ := os.Getwd()
@@ -170,9 +197,11 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			default:
 				dls := []*gitlab.Discussion{
 					{
+						ID: "already-1",
 						Notes: []*gitlab.Note{
 							{
-								Body: commentutil.MarkdownComment(alreadyCommented1),
+								Body:       metaBodyForNote(t, alreadyCommented1, "tool-name"),
+								Resolvable: true,
 								Position: &gitlab.NotePosition{
 									NewPath: alreadyCommented1.Result.Diagnostic.GetLocation().GetPath(),
 									NewLine: int64(alreadyCommented1.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine()),
@@ -195,9 +224,11 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			case "2":
 				dls := []*gitlab.Discussion{
 					{
+						ID: "already-2",
 						Notes: []*gitlab.Note{
 							{
-								Body: commentutil.MarkdownComment(alreadyCommented2),
+								Body:       metaBodyForNote(t, alreadyCommented2, "tool-name"),
+								Resolvable: true,
 								Position: &gitlab.NotePosition{
 									NewPath: alreadyCommented2.Result.Diagnostic.GetLocation().GetPath(),
 									NewLine: int64(alreadyCommented2.Result.Diagnostic.GetLocation().GetRange().GetStart().GetLine()),
@@ -220,7 +251,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 			switch *got.Position.NewPath {
 			case "file.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment1)),
+					Body: gitlab.Ptr(metaBody(t, newComment1, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -235,7 +266,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				}
 			case "file2.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment2)),
+					Body: gitlab.Ptr(metaBody(t, newComment2, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -250,7 +281,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 				}
 			case "new_file.go":
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(commentutil.MarkdownComment(newComment3)),
+					Body: gitlab.Ptr(metaBody(t, newComment3, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -266,11 +297,8 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 					t.Error(diff)
 				}
 			case "file3.go":
-				suggestions := buildSuggestions(newCommentWithSuggestion)
-				bodyExpected := commentutil.MarkdownComment(newCommentWithSuggestion) + "\n\n" + suggestions
-
 				want := &gitlab.CreateMergeRequestDiscussionOptions{
-					Body: gitlab.Ptr(bodyExpected),
+					Body: gitlab.Ptr(metaBody(t, newCommentWithSuggestion, "tool-name")),
 					Position: &gitlab.PositionOptions{
 						BaseSHA:      gitlab.Ptr("xxx"),
 						StartSHA:     gitlab.Ptr("xxx"),
@@ -315,6 +343,7 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 	}
 
 	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha")
+	g.SetTool("tool-name", "")
 
 	for _, c := range comments {
 		if err := g.Post(context.Background(), c); err != nil {
@@ -326,6 +355,401 @@ func TestGitLabMergeRequestDiscussionCommenter_Post_Flush_review_api(t *testing.
 	}
 	if postCalled != wantPostCalled {
 		t.Errorf("%d discussions posted, but want %d", postCalled, wantPostCalled)
+	}
+}
+
+func TestGitLabMergeRequestDiscussionCommenter_Flush_resolvesOutdatedDiscussions(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	// Diagnostic that WILL be reported again this run — must not be resolved.
+	stillReported := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 1}},
+				},
+				Message: "still reported",
+			},
+			InDiffFile: true,
+		},
+	}
+	// Diagnostic that was previously posted but is NOT reported this run —
+	// its discussion should be resolved.
+	fixed := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 2}},
+				},
+				Message: "fixed in new run",
+			},
+			InDiffFile: true,
+		},
+	}
+	// A previously-posted comment from a DIFFERENT tool must not be resolved
+	// even if not reported this run.
+	otherTool := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 3}},
+				},
+				Message: "from another tool",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	var resolved sync.Map
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			// Accept the POST for stillReported? It won't POST since it's already posted.
+			// If any unexpected POST happens, record it.
+			if r.Method == http.MethodPost {
+				t.Errorf("unexpected discussion create: %v", r.URL)
+				return
+			}
+			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
+			return
+		}
+		dls := []*gitlab.Discussion{
+			{
+				ID: "disc-still-reported",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, stillReported, "tool-name"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 1,
+					},
+				}},
+			},
+			{
+				ID: "disc-fixed",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, fixed, "tool-name"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 2,
+					},
+				}},
+			},
+			{
+				ID: "disc-already-resolved",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, fixed, "tool-name"),
+					Resolvable: true,
+					Resolved:   true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 9,
+					},
+				}},
+			},
+			{
+				ID: "disc-other-tool",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, otherTool, "different-tool"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 3,
+					},
+				}},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(dls); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// Resolve endpoint: PUT /projects/:id/merge_requests/:mr/discussions/:discussion_id
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("unexpected method on resolve: %v %v", r.Method, r.URL)
+			return
+		}
+		// URL form: .../discussions/<id>
+		parts := strings.Split(r.URL.Path, "/")
+		id := parts[len(parts)-1]
+		if r.URL.Query().Get("resolved") != "true" {
+			// client-go sends as JSON body, not query; accept either.
+			var opts gitlab.ResolveMergeRequestDiscussionOptions
+			_ = json.NewDecoder(r.Body).Decode(&opts)
+			if opts.Resolved == nil || !*opts.Resolved {
+				t.Errorf("expected resolve=true, got %+v", opts)
+			}
+		}
+		resolved.Store(id, true)
+		if err := json.NewEncoder(w).Encode(gitlab.Discussion{ID: id}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha")
+	g.SetTool("tool-name", "")
+	// Only report the stillReported diagnostic — fixed/otherTool are absent this run.
+	if err := g.Post(context.Background(), stillReported); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if _, ok := resolved.Load("disc-fixed"); !ok {
+		t.Errorf("expected disc-fixed to be resolved")
+	}
+	if _, ok := resolved.Load("disc-still-reported"); ok {
+		t.Errorf("disc-still-reported must NOT be resolved (diagnostic is still reported)")
+	}
+	if _, ok := resolved.Load("disc-other-tool"); ok {
+		t.Errorf("disc-other-tool must NOT be resolved (different tool)")
+	}
+	if _, ok := resolved.Load("disc-already-resolved"); ok {
+		t.Errorf("disc-already-resolved must NOT be re-resolved")
+	}
+}
+
+// TestGitLabMergeRequestDiscussionCommenter_Flush_skipsUnresolvable verifies
+// that discussions whose note is marked Resolvable=false are never passed to
+// the resolve endpoint, even when the diagnostic is no longer reported this
+// run.
+func TestGitLabMergeRequestDiscussionCommenter_Flush_skipsUnresolvable(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	unresolvable := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 6}},
+				},
+				Message: "unresolvable thread",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			dls := []*gitlab.Discussion{
+				{
+					ID: "disc-unresolvable",
+					Notes: []*gitlab.Note{{
+						Body:       metaBodyForNote(t, unresolvable, "tool-name"),
+						Resolvable: false,
+						Position: &gitlab.NotePosition{
+							NewPath: "file.go",
+							NewLine: 6,
+						},
+					}},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(dls); err != nil {
+				t.Fatal(err)
+			}
+		default:
+			t.Errorf("unexpected method: %v %v", r.Method, r.URL)
+		}
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected resolve call: %v %v", r.Method, r.URL)
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha")
+	g.SetTool("tool-name", "")
+	// Do NOT re-report `unresolvable` — this would normally trigger a resolve,
+	// but Resolvable=false must prevent that.
+	if err := g.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}
+
+// TestGitLabMergeRequestDiscussionCommenter_Flush_propagatesResolveError
+// ensures a failing resolve surfaces as a Flush error rather than being
+// silently swallowed.
+func TestGitLabMergeRequestDiscussionCommenter_Flush_propagatesResolveError(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	fixed := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 2}},
+				},
+				Message: "fixed in new run",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %v", r.Method)
+			return
+		}
+		dls := []*gitlab.Discussion{{
+			ID: "disc-fixed",
+			Notes: []*gitlab.Note{{
+				Body:       metaBodyForNote(t, fixed, "tool-name"),
+				Resolvable: true,
+				Position: &gitlab.NotePosition{
+					NewPath: "file.go",
+					NewLine: 2,
+				},
+			}},
+		}}
+		_ = json.NewEncoder(w).Encode(dls)
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/disc-fixed", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha")
+	g.SetTool("tool-name", "")
+	// Do not re-post `fixed` — it becomes outdated and triggers a resolve,
+	// which the mock server rejects with 500.
+	err = g.Flush(context.Background())
+	if err == nil {
+		t.Fatalf("expected Flush error, got nil")
+	}
+	if !strings.Contains(err.Error(), "disc-fixed") {
+		t.Errorf("expected error to reference discussion id, got: %v", err)
+	}
+}
+
+// TestGitLabMergeRequestDiscussionCommenter_Flush_paginatedOutdated confirms
+// that outdated discussions appearing on page 2+ of the discussion listing are
+// still picked up for auto-resolve.
+func TestGitLabMergeRequestDiscussionCommenter_Flush_paginatedOutdated(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("../..")
+
+	fixed := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{
+					Path:  "file.go",
+					Range: &rdf.Range{Start: &rdf.Position{Line: 7}},
+				},
+				Message: "fixed on page 2",
+			},
+			InDiffFile: true,
+		},
+	}
+
+	var resolved sync.Map
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %v", r.Method)
+			return
+		}
+		switch r.URL.Query().Get("page") {
+		default:
+			w.Header().Add("X-Next-Page", "2")
+			_ = json.NewEncoder(w).Encode([]*gitlab.Discussion{})
+		case "2":
+			dls := []*gitlab.Discussion{{
+				ID: "disc-page2-fixed",
+				Notes: []*gitlab.Note{{
+					Body:       metaBodyForNote(t, fixed, "tool-name"),
+					Resolvable: true,
+					Position: &gitlab.NotePosition{
+						NewPath: "file.go",
+						NewLine: 7,
+					},
+				}},
+			}}
+			_ = json.NewEncoder(w).Encode(dls)
+		}
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14/discussions/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		resolved.Store(parts[len(parts)-1], true)
+		_ = json.NewEncoder(w).Encode(gitlab.Discussion{})
+	})
+	mux.HandleFunc("/api/v4/projects/o%2Fr/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"commit": {"id": "xxx"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := gitlab.NewClient("", gitlab.WithBaseURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGitLabMergeRequestDiscussionCommenter(cli, "o", "r", 14, "sha")
+	g.SetTool("tool-name", "")
+	if err := g.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if _, ok := resolved.Load("disc-page2-fixed"); !ok {
+		t.Errorf("expected disc-page2-fixed (page 2) to be resolved")
 	}
 }
 


### PR DESCRIPTION
Fix #1150

Mirror the GitHub/Gitea fingerprint meta-comment pattern (introduced in #1792 / #1804) on the `gitlab-mr-discussion` reporter. Each posted note now embeds a fingerprint + tool-name meta comment. On subsequent runs, reviewdog-authored discussions whose diagnostic is no longer reported are automatically marked as **resolved** (via `PUT /projects/:id/merge_requests/:mr/discussions/:id`), keeping the MR review clean as fixes land.

Behavior matches `service/github` and `service/gitea`:
- Only notes whose `SourceName` equals the current run's `toolName` are candidates for auto-resolve.
- Discussions that are not resolvable (`Resolvable=false`) or already resolved are skipped.
- Notes that predate meta comments still deduplicate via raw body matching; they cannot be auto-resolved (no fingerprint).

Fingerprint collisions across discussions are preserved as a slice so no candidate is silently dropped, and every resolve failure is surfaced via `errors.Join`.

Resolve (rather than delete) is used because GitLab has a first-class resolved state for MR threads that preserves audit history — this matches the wording of the original feature request.

### Tests

New cases in `service/gitlab/gitlab_mr_discussion_test.go`:
- `..._resolvesOutdatedDiscussions` — fixed diagnostic resolved; still-reported, different-tool, and already-resolved discussions untouched.
- `..._skipsUnresolvableAndLegacy` — `Resolvable=false` notes and legacy (no-meta) notes are never passed to the resolve endpoint.
- `..._propagatesResolveError` — a 500 from the resolve endpoint surfaces as a `Flush` error referencing the discussion ID.
- `..._paginatedOutdated` — outdated discussions on page 2+ of the listing are picked up.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.