### PR TITLE
Fix SARIF diff filtering from subdirectories

### DIFF
--- a/parser/sarif.go
+++ b/parser/sarif.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/haya14busa/go-sarif/sarif"
 	"github.com/reviewdog/reviewdog/proto/rdf"
+	"github.com/reviewdog/reviewdog/service/serviceutil"
 )
 
 var _ Parser = &SarifParser{}
@@ -185,11 +186,32 @@ func getPath(
 	if err != nil {
 		return "", err
 	}
-	path := parse.Path
+	path := resolvePath(parse.Path, basedir)
 	if relpath, err := filepath.Rel(basedir, path); err == nil {
 		path = relpath
 	}
 	return path, nil
+}
+
+func resolvePath(path, basedir string) string {
+	if filepath.IsAbs(path) || basedir == "" {
+		return path
+	}
+
+	cwdPath := filepath.Join(basedir, path)
+	if _, err := os.Stat(cwdPath); err == nil {
+		return cwdPath
+	}
+
+	gitRoot, err := serviceutil.GetGitRoot()
+	if err != nil {
+		return path
+	}
+	gitRootPath := filepath.Join(gitRoot, path)
+	if _, err := os.Stat(gitRootPath); err == nil {
+		return gitRootPath
+	}
+	return path
 }
 
 func getText(msg sarif.Message) string {

--- a/parser/sarif.go
+++ b/parser/sarif.go
@@ -198,20 +198,11 @@ func resolvePath(path, basedir string) string {
 		return path
 	}
 
-	cwdPath := filepath.Join(basedir, path)
-	if _, err := os.Stat(cwdPath); err == nil {
-		return cwdPath
-	}
-
 	gitRoot, err := serviceutil.GetGitRoot()
-	if err != nil {
-		return path
+	if err == nil {
+		return filepath.Join(gitRoot, path)
 	}
-	gitRootPath := filepath.Join(gitRoot, path)
-	if _, err := os.Stat(gitRootPath); err == nil {
-		return gitRootPath
-	}
-	return path
+	return filepath.Join(basedir, path)
 }
 
 func getText(msg sarif.Message) string {

--- a/parser/sarif_test.go
+++ b/parser/sarif_test.go
@@ -179,7 +179,7 @@ var fixtures = [][]string{{
 }`, `{
 	"message": "message",
 	"location": {
-		"path": "src/MyClass.kt",
+		"path": "../src/MyClass.kt",
 		"range": {
 			"start": {
 				"line": 10
@@ -250,7 +250,7 @@ var fixtures = [][]string{{
 }`, `{
 	"message": "message",
 	"location": {
-		"path": "src/MyClass.kt",
+		"path": "../src/MyClass.kt",
 		"range": {
 			"start": {
 				"line": 10
@@ -410,7 +410,7 @@ var fixtures = [][]string{{
 `, basedir()), `{
 	"message": "Use of tainted variable 'expr' in the insecure function 'eval'.",
 	"location": {
-		"path": "3-Beyond-basics/bad-eval.py",
+		"path": "../3-Beyond-basics/bad-eval.py",
     "range": {
       "start": {
         "line": 4
@@ -427,7 +427,7 @@ var fixtures = [][]string{{
     {
       "message": "The tainted data entered the system here.",
 			"location": {
-				"path": "3-Beyond-basics/bad-eval.py",
+				"path": "../3-Beyond-basics/bad-eval.py",
 				"range": {
 					"start": {
 						"line": 3

--- a/reviewdog_test.go
+++ b/reviewdog_test.go
@@ -160,6 +160,92 @@ func TestReviewdog_Run_git_rel_dir_sarif(t *testing.T) {
 	defer os.Chdir(cwd)
 	os.Chdir("./_testdata/")
 
+	difftext := strings.Join([]string{
+		"diff --git a/missing.old.go b/missing.go",
+		"index 34cacb9..a727dd3 100644",
+		"--- a/_testdata/missing.old.go",
+		"+++ b/_testdata/missing.go",
+		"@@ -2,6 +2,12 @@ package test",
+		" ",
+		" var V int",
+		" ",
+		"+var NewError1 int",
+		"+",
+		" // invalid func comment",
+		" func F() {",
+		" }",
+		"+",
+		"+// invalid func comment2",
+		"+func F2() {",
+		"+}",
+	}, "\n")
+	sarifResult := `{
+  "runs": [
+    {
+      "results": [
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "_testdata/missing.go"
+                },
+                "region": {
+                  "startLine": 5,
+                  "startColumn": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "exported var NewError1 should have comment or be unexported"
+          }
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "sarif-tool"
+        }
+      }
+    }
+  ]
+}`
+
+	results, err := parser.NewSarifParser().Parse(strings.NewReader(sarifResult))
+	if err != nil {
+		t.Fatalf("parse sarif: %v", err)
+	}
+	workdir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	gitRelWorkdir, err := serviceutil.GitRelWorkdir()
+	if err != nil {
+		t.Fatalf("git rel workdir: %v", err)
+	}
+	pathutil.NormalizePathInResults(results, workdir, gitRelWorkdir)
+	if got := results[0].GetLocation().GetPath(); got != "_testdata/missing.go" {
+		t.Fatalf("path: got %v, want %v", got, "_testdata/missing.go")
+	}
+
+	filediffs, err := diff.ParseMultiFile(bytes.NewReader([]byte(difftext)))
+	if err != nil {
+		t.Fatalf("parse diff: %v", err)
+	}
+	checks := filter.FilterCheck(results, filediffs, 1, workdir, filter.ModeAdded)
+	if len(checks) != 1 {
+		t.Fatalf("got %d checks, want 1", len(checks))
+	}
+	if !checks[0].ShouldReport {
+		t.Fatal("expected SARIF diagnostic to be reported in subdirectory context")
+	}
+}
+
+func TestReviewdog_Run_git_rel_dir_sarif_prefers_git_root_relative_paths(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("./_testdata/")
+
 	content, err := os.ReadFile("golint.go")
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
@@ -167,8 +253,16 @@ func TestReviewdog_Run_git_rel_dir_sarif(t *testing.T) {
 	if err := os.WriteFile("golint.new.go", content, 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
+	if err := os.Mkdir("_testdata", 0o755); err != nil && !os.IsExist(err) {
+		t.Fatalf("mkdir nested fixture: %v", err)
+	}
+	if err := os.WriteFile("_testdata/golint.new.go", content, 0o644); err != nil {
+		t.Fatalf("write nested fixture: %v", err)
+	}
 	t.Cleanup(func() {
 		_ = os.Remove("golint.new.go")
+		_ = os.Remove("_testdata/golint.new.go")
+		_ = os.Remove("_testdata")
 	})
 
 	difftext := strings.Join([]string{
@@ -248,7 +342,7 @@ func TestReviewdog_Run_git_rel_dir_sarif(t *testing.T) {
 		t.Fatalf("got %d checks, want 1", len(checks))
 	}
 	if !checks[0].ShouldReport {
-		t.Fatal("expected SARIF diagnostic to be reported in subdirectory context")
+		t.Fatal("expected SARIF diagnostic to prefer git-root-relative paths")
 	}
 }
 

--- a/reviewdog_test.go
+++ b/reviewdog_test.go
@@ -1,6 +1,7 @@
 package reviewdog
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"strings"
@@ -8,8 +9,11 @@ import (
 
 	"github.com/reviewdog/errorformat"
 
+	"github.com/reviewdog/reviewdog/diff"
 	"github.com/reviewdog/reviewdog/filter"
 	"github.com/reviewdog/reviewdog/parser"
+	"github.com/reviewdog/reviewdog/pathutil"
+	"github.com/reviewdog/reviewdog/service/serviceutil"
 )
 
 var _ CommentService = &testWriter{}
@@ -149,6 +153,103 @@ index 34cacb9..a727dd3 100644
 	d := NewDiffString(difftext, 1)
 	app := NewReviewdog("tool name", p, c, d, filter.ModeAdded, FailLevelDefault)
 	app.Run(context.Background(), strings.NewReader(lintresult))
+}
+
+func TestReviewdog_Run_git_rel_dir_sarif(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir("./_testdata/")
+
+	content, err := os.ReadFile("golint.go")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile("golint.new.go", content, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove("golint.new.go")
+	})
+
+	difftext := strings.Join([]string{
+		"diff --git a/golint.old.go b/golint.new.go",
+		"index 34cacb9..a727dd3 100644",
+		"--- a/_testdata/golint.old.go",
+		"+++ b/_testdata/golint.new.go",
+		"@@ -2,6 +2,12 @@ package test",
+		" ",
+		" var V int",
+		" ",
+		"+var NewError1 int",
+		"+",
+		" // invalid func comment",
+		" func F() {",
+		" }",
+		"+",
+		"+// invalid func comment2",
+		"+func F2() {",
+		"+}",
+	}, "\n")
+	sarifResult := `{
+  "runs": [
+    {
+      "results": [
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "_testdata/golint.new.go"
+                },
+                "region": {
+                  "startLine": 5,
+                  "startColumn": 5
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "exported var NewError1 should have comment or be unexported"
+          }
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "sarif-tool"
+        }
+      }
+    }
+  ]
+}`
+
+	results, err := parser.NewSarifParser().Parse(strings.NewReader(sarifResult))
+	if err != nil {
+		t.Fatalf("parse sarif: %v", err)
+	}
+	workdir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	gitRelWorkdir, err := serviceutil.GitRelWorkdir()
+	if err != nil {
+		t.Fatalf("git rel workdir: %v", err)
+	}
+	pathutil.NormalizePathInResults(results, workdir, gitRelWorkdir)
+	if got := results[0].GetLocation().GetPath(); got != "_testdata/golint.new.go" {
+		t.Fatalf("path: got %v, want %v", got, "_testdata/golint.new.go")
+	}
+
+	filediffs, err := diff.ParseMultiFile(bytes.NewReader([]byte(difftext)))
+	if err != nil {
+		t.Fatalf("parse diff: %v", err)
+	}
+	checks := filter.FilterCheck(results, filediffs, 1, workdir, filter.ModeAdded)
+	if len(checks) != 1 {
+		t.Fatalf("got %d checks, want 1", len(checks))
+	}
+	if !checks[0].ShouldReport {
+		t.Fatal("expected SARIF diagnostic to be reported in subdirectory context")
+	}
 }
 
 func TestReviewdog_Run_returns_nil_if_fail_on_error_not_passed_and_some_errors_found(t *testing.T) {


### PR DESCRIPTION
Fixes #2105.

When reviewdog runs from a subdirectory, SARIF results can include paths that are relative to the git root. The SARIF parser passed those paths through unchanged, and the later normalization step treated them as if they were cwd-relative and prefixed the subdirectory again. That made diff filtering miss the file entirely.

This makes SARIF relative artifact paths deterministic: when reviewdog is inside a git repository, they are resolved from the git root before being converted back relative to the current working directory. Outside a git repository, they still resolve from the current working directory.

The regression coverage now checks both:
- a repo-root-relative SARIF path for a file that does not exist on disk
- the ambiguous case where both `cwd/path` and `git-root/path` exist, and the git-root-relative interpretation must win

Validation:
- `git diff --check`
- `go test . -run 'TestReviewdog_Run_git_rel_dir_sarif|TestReviewdog_Run_git_rel_dir_sarif_prefers_git_root_relative_paths' -count=1 -v`\n- `go test ./... -run 'TestReviewdog_Run_git_rel_dir_sarif|TestReviewdog_Run_git_rel_dir_sarif_prefers_git_root_relative_paths|TestReviewdog_Run_git_rel_dir|TestReviewdog_Run_clean_path|TestExampleSarifParser'`\n- `go test ./service/github -run TestGitHubPullRequest_Post_Flush_review_api` still fails on a fresh clean clone of `master`, so that unrelated failure is pre-existing