### PR TITLE
fix(parser/sarif): honor result.suppressions per SARIF 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :bug: Fixes
 
+- [#2586](https://github.com/reviewdog/reviewdog/pull/2586) Honor SARIF `result.suppressions` in SARIF parser — suppressed results (per SARIF 2.1.0 §3.27.23 / §3.35) no longer emit diagnostics
 - [#2481](https://github.com/reviewdog/reviewdog/pull/2481) Use CWD instead of git root in SARIF parser to prevent path doubling
 
 ### :rotating_light: Breaking changes

--- a/parser/sarif.go
+++ b/parser/sarif.go
@@ -45,6 +45,9 @@ func (p *SarifParser) Parse(r io.Reader) ([]*rdf.Diagnostic, error) {
 			rules[rule.ID] = rule
 		}
 		for _, result := range run.Results {
+			if isSuppressed(result.Suppressions) {
+				continue
+			}
 			original, err := json.Marshal(result)
 			if err != nil {
 				return nil, err
@@ -190,6 +193,19 @@ func getPath(
 		path = relpath
 	}
 	return path, nil
+}
+
+// isSuppressed reports whether a SARIF result should be skipped because the
+// tool already accepted a suppression for it. Per SARIF 2.1.0 §3.35.3, a
+// Suppression's status defaults to "accepted" when the property is absent;
+// only "rejected" and "underReview" indicate the suppression is not honored.
+func isSuppressed(suppressions []sarif.Suppression) bool {
+	for _, s := range suppressions {
+		if s.Status == nil || *s.Status == sarif.Accepted {
+			return true
+		}
+	}
+	return false
 }
 
 func getText(msg sarif.Message) string {

--- a/parser/sarif_test.go
+++ b/parser/sarif_test.go
@@ -43,6 +43,97 @@ func TestExampleSarifParser(t *testing.T) {
 	}
 }
 
+func TestSarifParser_Suppressions(t *testing.T) {
+	// SARIF 2.1.0 §3.27.23 + §3.35: a result with an "accepted" suppression
+	// (Status absent or explicitly "accepted") should be skipped. Status
+	// "rejected" or "underReview" must still emit diagnostics.
+	sarifWithSuppression := func(suppressionsJSON string) string {
+		return `{
+			"version": "2.1.0",
+			"runs": [
+				{
+					"results": [
+						{
+							"level": "warning",
+							"locations": [
+								{
+									"physicalLocation": {
+										"artifactLocation": {"uri": "main.tf"},
+										"region": {"startLine": 1}
+									}
+								}
+							],
+							"message": {"text": "msg"},
+							"ruleId": "CKV_AWS_338"` + suppressionsJSON + `
+						}
+					],
+					"tool": {"driver": {"name": "checkov"}}
+				}
+			]
+		}`
+	}
+
+	cases := []struct {
+		name      string
+		input     string
+		wantCount int
+	}{
+		{
+			name:      "suppressed: kind inSource, status absent (defaults to accepted)",
+			input:     sarifWithSuppression(`, "suppressions": [{"kind": "inSource", "justification": "rationale"}]`),
+			wantCount: 0,
+		},
+		{
+			name:      "suppressed: kind inSource, status accepted",
+			input:     sarifWithSuppression(`, "suppressions": [{"kind": "inSource", "status": "accepted", "justification": "rationale"}]`),
+			wantCount: 0,
+		},
+		{
+			name:      "suppressed: kind external, status absent",
+			input:     sarifWithSuppression(`, "suppressions": [{"kind": "external"}]`),
+			wantCount: 0,
+		},
+		{
+			name:      "not suppressed: status rejected",
+			input:     sarifWithSuppression(`, "suppressions": [{"kind": "inSource", "status": "rejected"}]`),
+			wantCount: 1,
+		},
+		{
+			name:      "not suppressed: status underReview",
+			input:     sarifWithSuppression(`, "suppressions": [{"kind": "inSource", "status": "underReview"}]`),
+			wantCount: 1,
+		},
+		{
+			name:      "not suppressed: empty suppressions array",
+			input:     sarifWithSuppression(`, "suppressions": []`),
+			wantCount: 1,
+		},
+		{
+			name:      "not suppressed: suppressions field absent",
+			input:     sarifWithSuppression(``),
+			wantCount: 1,
+		},
+		{
+			name:      "suppressed: at least one accepted suppression among mixed",
+			input:     sarifWithSuppression(`, "suppressions": [{"kind": "inSource", "status": "rejected"}, {"kind": "inSource", "status": "accepted"}]`),
+			wantCount: 0,
+		},
+	}
+
+	p := NewSarifParser()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diagnostics, err := p.Parse(strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+			if got := len(diagnostics); got != tc.wantCount {
+				t.Errorf("len(diagnostics) = %d, want %d", got, tc.wantCount)
+			}
+		})
+	}
+}
+
 func basedir() string {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Problem

The SARIF parser ([parser/sarif.go](https://github.com/reviewdog/reviewdog/blob/master/parser/sarif.go)) ignores the `result.suppressions` field. Every result becomes a diagnostic regardless of whether the producing tool already accepted a suppression inline.

In real CI workflows this manifests as inline suppressions being silently dropped on the floor. Example with Checkov:

```hcl
resource "aws_cloudwatch_log_group" "this" {
  # checkov:skip=CKV_AWS_338: default 30d for cost; consumers raise via var.log_retention_days
  name              = local.name
  retention_in_days = var.log_retention_days
}
```

Checkov honors the comment and emits the finding into SARIF with `suppressions` populated:

```json
{
  "ruleId": "CKV_AWS_338",
  "level": "warning",
  "locations": [...],
  "suppressions": [
    {"kind": "inSource", "justification": "default 30d for cost; consumers raise via var..."}
  ]
}
```

reviewdog re-emits this as a diagnostic. With `fail-level=warning` the merge is blocked despite the user explicitly suppressing the finding upstream.

## Fix

Skip results carrying an accepted suppression at the top of the result loop. Single-helper, single-line skip:

```go
for _, result := range run.Results {
    if isSuppressed(result.Suppressions) {
        continue
    }
    // ... existing logic unchanged
}
```

`isSuppressed` returns true iff at least one `Suppression` has `Status` nil or `Status == "accepted"`. Status `"rejected"` and `"underReview"` still emit diagnostics, matching the spec.

## Spec references

- [SARIF 2.1.0 §3.27.23](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012592) — `result.suppressions` property
- [SARIF 2.1.0 §3.35](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012602) — Suppression object (kind: `inSource` | `external`)
- [SARIF 2.1.0 §3.35.3](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012605) — Status semantics: absent property defaults to `accepted`

## Tests

New `TestSarifParser_Suppressions` (`parser/sarif_test.go`) covering 8 sub-cases:

| Case | Expected diagnostics |
|---|---|
| `kind: inSource`, status absent (defaults to accepted) | 0 |
| `kind: inSource, status: accepted` | 0 |
| `kind: external`, status absent | 0 |
| `kind: inSource, status: rejected` | 1 |
| `kind: inSource, status: underReview` | 1 |
| Empty `suppressions: []` | 1 |
| `suppressions` field absent | 1 |
| Mixed (one accepted, one rejected) | 0 |

Validation run locally:

```
go test ./parser/...     # passes
go vet ./...             # clean
gofmt -l parser/         # no output
```

End-to-end sanity with a real Checkov SARIF (2 suppressed findings):
- Before fix: reviewdog emits 2 diagnostics
- After fix: reviewdog emits 0 diagnostics

## Use case

Discovered while integrating Checkov + reviewdog for Terraform module CI. The same pattern applies to any SARIF-emitting tool with inline suppression support: CodeQL, Semgrep, Bandit, tfsec.

## Checklist

- [x] Updated Unreleased section in CHANGELOG.md