### PR TITLE
parser/rdjsonl: propagate scanner errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#2586](https://github.com/reviewdog/reviewdog/pull/2586) Honor SARIF `result.suppressions` in SARIF parser — suppressed results (per SARIF 2.1.0 §3.27.23 / §3.35) no longer emit diagnostics
 - [#2481](https://github.com/reviewdog/reviewdog/pull/2481) Use CWD instead of git root in SARIF parser to prevent path doubling
+- [#2663](https://github.com/reviewdog/reviewdog/pull/2663) Fix deadlock when parsing too-long RDJSONL lines.
 
 ### :rotating_light: Breaking changes
 - doghouse: the `/check` endpoint (used by `-reporter=github-pr-check` via reviewdog.app) now always requires `REVIEWDOG_TOKEN`. The previous shortcut that accepted requests from certain CI providers without a token has been removed. Users who relied on the token-less path (e.g. AppVeyor) must now set `REVIEWDOG_TOKEN` explicitly. Tokens can be obtained from `https://reviewdog.app/gh/<owner>/<repo-name>`.

--- a/parser/rdjsonl.go
+++ b/parser/rdjsonl.go
@@ -35,5 +35,5 @@ func (p *RDJSONLParser) Parse(r io.Reader) ([]*rdf.Diagnostic, error) {
 		}
 		results = append(results, d)
 	}
-	return results, nil
+	return results, s.Err()
 }

--- a/parser/rdjsonl_test.go
+++ b/parser/rdjsonl_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bufio"
 	"strings"
 	"testing"
 )
@@ -23,5 +24,14 @@ func TestRDJSONLParser(t *testing.T) {
 		if got, want := d.GetOriginalOutput(), sampleLines[i]; got != want {
 			t.Errorf("%d: got %v, want %v", i, got, want)
 		}
+	}
+}
+
+func TestRDJSONLParserLineTooLong(t *testing.T) {
+	longLine := strings.Repeat("a", bufio.MaxScanTokenSize)
+	p := NewRDJSONLParser()
+	_, err := p.Parse(strings.NewReader(longLine))
+	if err != bufio.ErrTooLong {
+		t.Errorf("expected bufio.ErrTooLong, got %s", err)
 	}
 }

--- a/proto/rdf/README.md
+++ b/proto/rdf/README.md
@@ -41,6 +41,7 @@ tools.
 
 ### **rdjsonl**
 JSON Lines (http://jsonlines.org/) of the [`Diagnostic`](reviewdog.proto) message ([JSON Schema](./jsonschema/Diagnostic.json)).
+Each line must be less than 64 KiB in length, including the line terminator.
 
 Example:
 ```json


### PR DESCRIPTION
bufio.Scanner can encounter errors in a few cases, including exhausting its internal buffer while scanning a very long token (line). When it does so, it stops consuming input from its io.Reader.

In the case of a too-long line, if we don't check for scanner errors, RunAndParse thinks the process has finished and waits for it to exit. In reality, the process may be blocked writing to its stdout/stderr. This situation causes a deadlock and reviewdog freezes indefinitely.

If we at least propagate scanner errors to the caller, we can avoid deadlock and provide a useful error message.


- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

