### PR TITLE
Update Gitea PR reporter support to be in par with GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2257](https://github.com/reviewdog/reviewdog/pull/2257) Use -trimpath flag for reproducible build
 - [#2513](https://github.com/reviewdog/reviewdog/pull/2513) Drop support of windows/arm
 - [#2543](https://github.com/reviewdog/reviewdog/pull/2543) Update `gitlab-mr-discussion` reporter to embed a fingerprint meta-comment in each posted note and automatically resolve previously-posted discussions whose diagnostic is no longer reported (fixes [#1150](https://github.com/reviewdog/reviewdog/issues/1150)).
+- [#2747](https://github.com/reviewdog/reviewdog/pull/2747) Update `gitea-pr-review` reporter to be on par with `github-pr-review`: report results outside the diff context as pull request comments, fallback to Actions logging commands for results outside the diff file and honor the `-level` flag.
 
 ### :bug: Fixes
 

--- a/README.md
+++ b/README.md
@@ -943,12 +943,13 @@ so reviewdog will use [Check annotation](https://docs.github.com/en/rest/checks/
 | **`gitlab-mr-commit`**       | OK      | Partially Supported [2] | Partially Supported [2] | Partially Supported [2] |
 | **`gerrit-change-review`**   | OK      | OK? [3]        | OK? [3]                 | Partially Supported? [2][3] |
 | **`bitbucket-code-report`**  | NO [4]  | NO [4]         | NO [4]                  | OK |
-| **`gitea-pr-review`**        | OK      | OK             | Partially Supported [2] | Partially Supported [2] |
+| **`gitea-pr-review`**        | OK      | OK             | Partially Supported [5] | Partially Supported [5] |
 
 - [1] Report results that are outside the diff file with Check annotation as fallback if it's running in GitHub actions instead of Review API (comments). All results will be reported to console as well.
 - [2] Report results that are outside the diff file to console.
 - [3] It should work, but not been verified yet.
 - [4] Not implemented at the moment
+- [5] Report results that are outside the diff context as pull request comments and results that are outside the diff file with Actions logging commands as fallback if it's running in Gitea Actions. All results will be reported to console as well.
 
 ## Debugging
 

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"code.gitea.io/sdk/gitea"
+	gitea "gitea.dev/sdk"
 	"golang.org/x/build/gerrit"
 	"golang.org/x/oauth2"
 
@@ -555,7 +555,7 @@ func giteaService(ctx context.Context, opt *option) (gs *giteaservice.PullReques
 			return nil, false, nil
 		}
 
-		prID, err := getGiteaPullRequestIDByBranchOrCommit(client, g)
+		prID, err := getGiteaPullRequestIDByBranchOrCommit(ctx, client, g)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return nil, false, nil
@@ -575,7 +575,7 @@ func giteaService(ctx context.Context, opt *option) (gs *giteaservice.PullReques
 	return gs, true, nil
 }
 
-func getGiteaPullRequestIDByBranchOrCommit(client *gitea.Client, info *cienv.BuildInfo) (int64, error) {
+func getGiteaPullRequestIDByBranchOrCommit(ctx context.Context, client *gitea.Client, info *cienv.BuildInfo) (int64, error) {
 	options := gitea.ListPullRequestsOptions{
 		Sort:  "updated",
 		State: gitea.StateOpen,
@@ -586,7 +586,7 @@ func getGiteaPullRequestIDByBranchOrCommit(client *gitea.Client, info *cienv.Bui
 	}
 
 	for {
-		pullRequests, resp, err := client.ListRepoPullRequests(info.Owner, info.Repo, options)
+		pullRequests, resp, err := client.PullRequests.ListRepoPullRequests(ctx, info.Owner, info.Repo, options)
 		if err != nil {
 			return 0, err
 		}
@@ -624,7 +624,6 @@ func getGiteaPullRequestIDByBranchOrCommit(client *gitea.Client, info *cienv.Bui
 
 func giteaClient(ctx context.Context, url, token string) (*gitea.Client, error) {
 	client, err := gitea.NewClient(url,
-		gitea.SetContext(ctx),
 		gitea.SetToken(token),
 		gitea.SetHTTPClient(newHTTPClient()),
 	)
@@ -632,7 +631,7 @@ func giteaClient(ctx context.Context, url, token string) (*gitea.Client, error) 
 		return nil, err
 	}
 
-	return client, client.CheckServerVersionConstraint(">=1.17.0")
+	return client, client.CheckServerVersionConstraint(ctx, ">=1.17.0")
 }
 
 func githubService(ctx context.Context, opt *option) (gs *githubservice.PullRequest, isPR bool, err error) {

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -563,7 +563,7 @@ func giteaService(ctx context.Context, opt *option) (gs *giteaservice.PullReques
 		g.PullRequest = int(prID)
 	}
 
-	gs, err = giteaservice.NewGiteaPullRequest(client, g.Owner, g.Repo, int64(g.PullRequest), g.SHA, toolName(opt))
+	gs, err = giteaservice.NewGiteaPullRequest(client, g.Owner, g.Repo, int64(g.PullRequest), g.SHA, opt.level, toolName(opt))
 	if err != nil {
 		return nil, false, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.0
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/datastore v1.26.0
-	code.gitea.io/sdk/gitea v0.25.1
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.12
+	gitea.dev/sdk v1.2.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v90 v90.0.0
@@ -43,7 +43,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,11 +58,11 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/trace v1.0.0/go.mod h1:4iErSByzxkyHWzzlAj63/Gmjz0NH1ASqhJguHpGcr6A=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
-code.gitea.io/sdk/gitea v0.25.1 h1:yywxWwoV+SdjHtbC6unBiXojWdZOtoHuGhEazEXeWuE=
-code.gitea.io/sdk/gitea v0.25.1/go.mod h1:uDFWYBU8dgZsgOHwe6C/6olxvf8FHguNB3wW1i83fgg=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.12 h1:bjBKzIf7/TAkxd7L2utGaLM78bmUWlCval5K9UeElbY=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.12/go.mod h1:mmxnWlrvrFdpiOHOhxBaVi1rkc0WOqhgfknj4Yg0SeQ=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+gitea.dev/sdk v1.2.0 h1:avRtJl/nKCGispgSalo9czoZM9Rto1awnE0caNAoXGo=
+gitea.dev/sdk v1.2.0/go.mod h1:rfh5oNdIK24cbCREwIn1tqWKQW+IICXFGWJyebuOAOE=
 github.com/42wim/httpsig v1.2.4 h1:mI5bH0nm4xn7K18fo1K3okNDRq8CCJ0KbBYWyA6r8lU=
 github.com/42wim/httpsig v1.2.4/go.mod h1:yKsYfSyTBEohkPik224QPFylmzEBtda/kjyIAJjh3ps=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -115,8 +115,6 @@ github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4Nij
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
-github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/service/gitea/diff.go
+++ b/service/gitea/diff.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 
-	"code.gitea.io/sdk/gitea"
+	gitea "gitea.dev/sdk"
 	"github.com/reviewdog/reviewdog"
 )
 
@@ -31,7 +31,7 @@ func (p *PullRequestDiffService) Strip() int {
 
 // Diff returns a diff of PullRequest.
 func (p *PullRequestDiffService) Diff(ctx context.Context) ([]byte, error) {
-	d, resp, err := p.Cli.GetPullRequestDiff(p.Owner, p.Repo, p.PR, gitea.PullRequestDiffOptions{
+	d, resp, err := p.Cli.PullRequests.GetPullRequestDiff(ctx, p.Owner, p.Repo, p.PR, gitea.PullRequestDiffOptions{
 		Binary: false,
 	})
 	if err != nil {
@@ -47,7 +47,7 @@ func (p *PullRequestDiffService) Diff(ctx context.Context) ([]byte, error) {
 
 // diffUsingGitCommand returns a diff of PullRequest using git command.
 func (p *PullRequestDiffService) diffUsingGitCommand(ctx context.Context) ([]byte, error) {
-	pr, _, err := p.Cli.GetPullRequest(p.Owner, p.Repo, p.PR)
+	pr, _, err := p.Cli.PullRequests.GetPullRequest(ctx, p.Owner, p.Repo, p.PR)
 	if err != nil {
 		return nil, err
 	}

--- a/service/gitea/gitea.go
+++ b/service/gitea/gitea.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"code.gitea.io/sdk/gitea"
+	gitea "gitea.dev/sdk"
 	"github.com/reviewdog/reviewdog"
 	"github.com/reviewdog/reviewdog/pathutil"
 	"github.com/reviewdog/reviewdog/proto/rdf"
@@ -74,15 +74,15 @@ func (g *PullRequest) Post(_ context.Context, c *reviewdog.Comment) error {
 func (*PullRequest) ShouldPrependGitRelDir() bool { return true }
 
 // Flush posts comments which has not been posted yet.
-func (g *PullRequest) Flush(_ context.Context) error {
+func (g *PullRequest) Flush(ctx context.Context) error {
 	g.muComments.Lock()
 	defer g.muComments.Unlock()
 	defer func() { g.postComments = nil }()
 
-	if err := g.setPostedComment(); err != nil {
+	if err := g.setPostedComment(ctx); err != nil {
 		return err
 	}
-	return g.postAsReviewComment()
+	return g.postAsReviewComment(ctx)
 }
 
 // SetTool sets tool name to use in comments.
@@ -95,7 +95,7 @@ func (g *PullRequest) SetMaxCommentsPerReview(max int) {
 	g.maxCommentsPerReview = max
 }
 
-func (g *PullRequest) postAsReviewComment() error {
+func (g *PullRequest) postAsReviewComment(ctx context.Context) error {
 	postComments := g.postComments
 	g.postComments = nil
 	reviewComments := make([]gitea.CreatePullReviewComment, 0, len(postComments))
@@ -104,7 +104,7 @@ func (g *PullRequest) postAsReviewComment() error {
 	if err != nil {
 		return err
 	}
-	repoBaseHTMLURL, err := g.repoBaseHTMLURL()
+	repoBaseHTMLURL, err := g.repoBaseHTMLURL(ctx)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (g *PullRequest) postAsReviewComment() error {
 			Comments: reviewComments,
 			Body:     g.remainingCommentsSummary(remaining, repoBaseHTMLURL, rootPath),
 		}
-		_, _, err := g.cli.CreatePullReview(g.owner, g.repo, g.pr, review)
+		_, _, err := g.cli.PullRequests.CreatePullReview(ctx, g.owner, g.repo, g.pr, review)
 		if err != nil {
 			log.Printf("reviewdog: failed to post a review comment: %v", err)
 			return err
@@ -156,7 +156,7 @@ func (g *PullRequest) postAsReviewComment() error {
 			// Do not remove comment with replies.
 			continue
 		}
-		if _, err := g.cli.DeleteIssueComment(g.owner, g.repo, c.ID); err != nil {
+		if _, err := g.cli.Issues.DeleteIssueComment(ctx, g.owner, g.repo, c.ID); err != nil {
 			return fmt.Errorf("failed to delete comment (id=%d): %w", c.ID, err)
 		}
 	}
@@ -237,11 +237,11 @@ func (g *PullRequest) remainingCommentsSummary(remaining []*reviewdog.Comment, b
 }
 
 // setPostedComment get posted comments from Gitea.
-func (g *PullRequest) setPostedComment() error {
+func (g *PullRequest) setPostedComment(ctx context.Context) error {
 	g.postedcs = make(commentutil.PostedComments)
 	g.outdatedComments = make(map[string]*gitea.PullReviewComment)
 	g.prCommentWithReply = make(map[int64]bool)
-	cs, err := g.comment()
+	cs, err := g.comment(ctx)
 	if err != nil {
 		return err
 	}
@@ -283,16 +283,16 @@ func (g *PullRequest) Strip() int {
 	return 1
 }
 
-func (g *PullRequest) repoBaseHTMLURL() (string, error) {
-	repo, _, err := g.cli.GetRepo(g.owner, g.repo)
+func (g *PullRequest) repoBaseHTMLURL(ctx context.Context) (string, error) {
+	repo, _, err := g.cli.Repositories.GetRepo(ctx, g.owner, g.repo)
 	if err != nil {
 		return "", fmt.Errorf("failed to build repo base HTML URL: %w", err)
 	}
 	return url.JoinPath(repo.HTMLURL, "src", "commit", g.sha)
 }
 
-func (g *PullRequest) comment() ([]*gitea.PullReviewComment, error) {
-	prs, err := listAllPullRequestReviews(g.cli, g.owner, g.repo, g.pr, gitea.ListPullReviewsOptions{
+func (g *PullRequest) comment(ctx context.Context) ([]*gitea.PullReviewComment, error) {
+	prs, err := listAllPullRequestReviews(ctx, g.cli, g.owner, g.repo, g.pr, gitea.ListPullReviewsOptions{
 		ListOptions: gitea.ListOptions{
 			Page:     1,
 			PageSize: 100,
@@ -304,7 +304,7 @@ func (g *PullRequest) comment() ([]*gitea.PullReviewComment, error) {
 
 	comments := make([]*gitea.PullReviewComment, 0, len(prs))
 	for _, pr := range prs {
-		c, _, err := g.cli.ListPullReviewComments(g.owner, g.repo, g.pr, pr.ID)
+		c, _, err := g.cli.PullRequests.ListPullReviewComments(ctx, g.owner, g.repo, g.pr, pr.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -315,10 +315,10 @@ func (g *PullRequest) comment() ([]*gitea.PullReviewComment, error) {
 	return comments, nil
 }
 
-func listAllPullRequestReviews(cli *gitea.Client,
+func listAllPullRequestReviews(ctx context.Context, cli *gitea.Client,
 	owner, repo string, pr int64, opts gitea.ListPullReviewsOptions,
 ) ([]*gitea.PullReview, error) {
-	reviews, resp, err := cli.ListPullReviews(owner, repo, pr, opts)
+	reviews, resp, err := cli.PullRequests.ListPullReviews(ctx, owner, repo, pr, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func listAllPullRequestReviews(cli *gitea.Client,
 		},
 	}
 
-	restReviews, err := listAllPullRequestReviews(cli, owner, repo, pr, newOpts)
+	restReviews, err := listAllPullRequestReviews(ctx, cli, owner, repo, pr, newOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/service/gitea/gitea.go
+++ b/service/gitea/gitea.go
@@ -5,25 +5,38 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
 	gitea "gitea.dev/sdk"
 	"github.com/reviewdog/reviewdog"
+	"github.com/reviewdog/reviewdog/cienv"
 	"github.com/reviewdog/reviewdog/pathutil"
 	"github.com/reviewdog/reviewdog/proto/rdf"
 	"github.com/reviewdog/reviewdog/service/commentutil"
+	"github.com/reviewdog/reviewdog/service/github/githubutils"
 	"github.com/reviewdog/reviewdog/service/serviceutil"
 )
 
 var _ reviewdog.CommentService = (*PullRequest)(nil)
 var _ reviewdog.DiffService = (*PullRequest)(nil)
 
+const maxFileComments = 10
+
 const (
 	invalidSuggestionPre  = "<details><summary>reviewdog suggestion error</summary>"
 	invalidSuggestionPost = "</details>"
 )
+
+func isPermissionError(resp *gitea.Response) bool {
+	if resp == nil || resp.Response == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound
+}
 
 // PullRequest is a comment and diff service for Gitea PullRequest.
 //
@@ -42,23 +55,35 @@ type PullRequest struct {
 	muComments           sync.Mutex
 	maxCommentsPerReview int
 	postComments         []*reviewdog.Comment
+	logWriter            *githubutils.GitHubActionLogWriter
+	fallbackToLog        bool
 
-	postedcs           commentutil.PostedComments
-	outdatedComments   map[string]*gitea.PullReviewComment // fingerprint -> comment
-	prCommentWithReply map[int64]bool                      // review id -> bool
+	postedcs              commentutil.PostedComments
+	outdatedComments      map[string]*gitea.PullReviewComment // fingerprint -> comment
+	prCommentWithReply    map[int64]bool                      // review id -> bool
+	postedIssueComments   map[string]bool                     // fingerprint -> posted
+	outdatedIssueComments map[string]*gitea.Comment           // fingerprint -> comment
 }
 
 // NewGiteaPullRequest returns a new PullRequest service.
 //
 // PullRequest service needs git command in $PATH.
-func NewGiteaPullRequest(cli *gitea.Client, owner, repo string, pr int64, sha, toolName string) (*PullRequest, error) {
+//
+// The Gitea Token may not have the necessary permissions.
+// For example, in the case of a PR from a forked repository.
+//
+// In such a case, the service will fallback to Gitea Actions workflow commands [1].
+//
+// [1]: https://docs.gitea.com/usage/actions/comparison
+func NewGiteaPullRequest(cli *gitea.Client, owner, repo string, pr int64, sha, level, toolName string) (*PullRequest, error) {
 	return &PullRequest{
-		cli:      cli,
-		owner:    owner,
-		repo:     repo,
-		pr:       pr,
-		sha:      sha,
-		toolName: toolName,
+		cli:       cli,
+		owner:     owner,
+		repo:      repo,
+		pr:        pr,
+		sha:       sha,
+		toolName:  toolName,
+		logWriter: githubutils.NewGitHubActionLogWriter(level),
 	}, nil
 }
 
@@ -85,9 +110,10 @@ func (g *PullRequest) Flush(ctx context.Context) error {
 	return g.postAsReviewComment(ctx)
 }
 
-// SetTool sets tool name to use in comments.
-func (g *PullRequest) SetTool(toolName string, _ string) {
+// SetTool sets tool name and level to use in comments.
+func (g *PullRequest) SetTool(toolName string, level string) {
 	g.toolName = toolName
+	g.logWriter = githubutils.NewGitHubActionLogWriter(level)
 }
 
 // SetMaxCommentsPerReview sets the maximum number of comments to post per review.
@@ -96,9 +122,22 @@ func (g *PullRequest) SetMaxCommentsPerReview(max int) {
 }
 
 func (g *PullRequest) postAsReviewComment(ctx context.Context) error {
+	if g.fallbackToLog {
+		// we don't have permission to post a review comment.
+		// Fallback to Gitea Actions log as report.
+		for _, c := range g.postComments {
+			if err := g.logWriter.Post(ctx, c); err != nil {
+				return err
+			}
+		}
+		return g.logWriter.Flush(ctx)
+	}
+
 	postComments := g.postComments
 	g.postComments = nil
+	rawComments := make([]*reviewdog.Comment, 0, len(postComments))
 	reviewComments := make([]gitea.CreatePullReviewComment, 0, len(postComments))
+	fileComments := make([]gitea.CreateIssueCommentOption, 0)
 	remaining := make([]*reviewdog.Comment, 0)
 	rootPath, err := serviceutil.GetGitRoot()
 	if err != nil {
@@ -110,30 +149,46 @@ func (g *PullRequest) postAsReviewComment(ctx context.Context) error {
 	}
 	for _, c := range postComments {
 		if !c.Result.InDiffFile {
+			// Gitea Review API cannot report results outside diff file. If it's running
+			// in Gitea Actions, fallback to Gitea Actions log as report.
+			if cienv.IsInGitHubAction() {
+				if err := g.logWriter.Post(ctx, c); err != nil {
+					return err
+				}
+			}
 			continue
 		}
 		fprint, err := serviceutil.Fingerprint(c.Result.Diagnostic)
 		if err != nil {
 			return err
 		}
-		if g.postedcs.IsPosted(c, giteaCommentLine(c), fprint) {
+		if g.postedcs.IsPosted(c, giteaCommentLine(c), fprint) || g.postedIssueComments[fprint] {
 			// it's already posted. Mark the comment as non-outdated and skip it.
 			delete(g.outdatedComments, fprint)
+			delete(g.outdatedIssueComments, fprint)
 			continue
 		}
+		rawComments = append(rawComments, c)
 
-		if !c.Result.InDiffContext {
-			// If the result is outside of diff context, skip it.
-			continue
+		if c.Result.InDiffContext {
+			// Only posts maxCommentsPerReview comments per review if option is set.
+			if g.maxCommentsPerReview != 0 && len(reviewComments) >= g.maxCommentsPerReview {
+				remaining = append(remaining, c)
+				continue
+			}
+			comment := buildReviewComment(c, buildBody(c, repoBaseHTMLURL, rootPath, fprint, g.toolName))
+			reviewComments = append(reviewComments, comment)
+		} else {
+			if len(fileComments) >= maxFileComments {
+				remaining = append(remaining, c)
+				continue
+			}
+			comment := gitea.CreateIssueCommentOption{Body: buildBody(c, repoBaseHTMLURL, rootPath, fprint, g.toolName)}
+			fileComments = append(fileComments, comment)
 		}
-
-		// Only posts maxCommentsPerReview comments per review if option is set.
-		if g.maxCommentsPerReview != 0 && len(reviewComments) >= g.maxCommentsPerReview {
-			remaining = append(remaining, c)
-			continue
-		}
-		comment := buildReviewComment(c, buildBody(c, repoBaseHTMLURL, rootPath, fprint, g.toolName))
-		reviewComments = append(reviewComments, comment)
+	}
+	if err := g.logWriter.Flush(ctx); err != nil {
+		return err
 	}
 
 	if len(reviewComments) > 0 || len(remaining) > 0 {
@@ -144,9 +199,25 @@ func (g *PullRequest) postAsReviewComment(ctx context.Context) error {
 			Comments: reviewComments,
 			Body:     g.remainingCommentsSummary(remaining, repoBaseHTMLURL, rootPath),
 		}
-		_, _, err := g.cli.PullRequests.CreatePullReview(ctx, g.owner, g.repo, g.pr, review)
+		_, resp, err := g.cli.PullRequests.CreatePullReview(ctx, g.owner, g.repo, g.pr, review)
 		if err != nil {
 			log.Printf("reviewdog: failed to post a review comment: %v", err)
+			// Gitea returns 403 or 404 if we don't have permission to post a review comment.
+			// fallback to log message in this case.
+			if isPermissionError(resp) && cienv.IsInGitHubAction() {
+				goto FALLBACK
+			}
+			return err
+		}
+	}
+	for _, c := range fileComments {
+		if _, resp, err := g.cli.Issues.CreateIssueComment(ctx, g.owner, g.repo, g.pr, c); err != nil {
+			log.Printf("reviewdog: failed to post a pull request comment: %v", err)
+			// Gitea returns 403 or 404 if we don't have permission to post a review comment.
+			// fallback to log message in this case.
+			if isPermissionError(resp) && cienv.IsInGitHubAction() {
+				goto FALLBACK
+			}
 			return err
 		}
 	}
@@ -160,8 +231,27 @@ func (g *PullRequest) postAsReviewComment(ctx context.Context) error {
 			return fmt.Errorf("failed to delete comment (id=%d): %w", c.ID, err)
 		}
 	}
+	for _, c := range g.outdatedIssueComments {
+		if _, err := g.cli.Issues.DeleteIssueComment(ctx, g.owner, g.repo, c.ID); err != nil {
+			return fmt.Errorf("failed to delete comment (id=%d): %w", c.ID, err)
+		}
+	}
 
 	return nil
+
+FALLBACK:
+	// fallback to Gitea Actions log as report.
+	fmt.Fprintln(os.Stderr, `reviewdog: This Gitea Token doesn't have write permission of Review API,
+so reviewdog will report results via logging command [1] and create annotations as a fallback.
+[1]: https://docs.gitea.com/usage/actions/comparison`)
+	g.fallbackToLog = true
+
+	for _, c := range rawComments {
+		if err := g.logWriter.Post(ctx, c); err != nil {
+			return err
+		}
+	}
+	return g.logWriter.Flush(ctx)
 }
 
 func buildReviewComment(c *reviewdog.Comment, body string) gitea.CreatePullReviewComment {
@@ -241,6 +331,8 @@ func (g *PullRequest) setPostedComment(ctx context.Context) error {
 	g.postedcs = make(commentutil.PostedComments)
 	g.outdatedComments = make(map[string]*gitea.PullReviewComment)
 	g.prCommentWithReply = make(map[int64]bool)
+	g.postedIssueComments = make(map[string]bool)
+	g.outdatedIssueComments = make(map[string]*gitea.Comment)
 	cs, err := g.comment(ctx)
 	if err != nil {
 		return err
@@ -260,6 +352,25 @@ func (g *PullRequest) setPostedComment(ctx context.Context) error {
 			g.postedcs.AddPostedComment(c.Path, int(c.LineNum), meta.GetFingerprint())
 			if meta.SourceName == g.toolName {
 				g.outdatedComments[meta.GetFingerprint()] = c // Remove non-outdated comment later.
+			}
+		}
+	}
+
+	issueComments, err := listAllIssueComments(ctx, g.cli, g.owner, g.repo, g.pr,
+		gitea.ListIssueCommentOptions{
+			ListOptions: gitea.ListOptions{
+				Page:     1,
+				PageSize: 100,
+			},
+		})
+	if err != nil {
+		return err
+	}
+	for _, c := range issueComments {
+		if meta := serviceutil.ExtractMetaComment(c.Body); meta != nil {
+			g.postedIssueComments[meta.GetFingerprint()] = true
+			if meta.SourceName == g.toolName {
+				g.outdatedIssueComments[meta.GetFingerprint()] = c // Remove non-outdated comment later.
 			}
 		}
 	}
@@ -340,6 +451,27 @@ func listAllPullRequestReviews(ctx context.Context, cli *gitea.Client,
 	}
 
 	return append(reviews, restReviews...), nil
+}
+
+func listAllIssueComments(ctx context.Context, cli *gitea.Client,
+	owner, repo string, pr int64, opts gitea.ListIssueCommentOptions,
+) ([]*gitea.Comment, error) {
+	comments, resp, err := cli.Issues.ListIssueComments(ctx, owner, repo, pr, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.NextPage == 0 {
+		return comments, nil
+	}
+
+	opts.Page = resp.NextPage
+	restComments, err := listAllIssueComments(ctx, cli, owner, repo, pr, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(comments, restComments...), nil
 }
 
 func buildBody(c *reviewdog.Comment, baseURL string, gitRootPath string, fprint string, toolName string) string {


### PR DESCRIPTION
Update `gitea-pr-review` reporter to be on par with `github-pr-review`:
* Report results outside the diff context as pull request comments
* Fallback to Actions logging commands for results outside the diff file
* Honor the `-level` flag.

- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

