### PR TITLE
fix: support multiple Bitbucket project runners

### DIFF
--- a/proto/rdf/reviewdog.pb.go
+++ b/proto/rdf/reviewdog.pb.go
@@ -450,11 +450,9 @@ type Position struct {
 	Line int32 `protobuf:"varint,1,opt,name=line,proto3" json:"line,omitempty"`
 	// Column number, starting at 1 (byte count in UTF-8).
 	// Example: 'a𐐀b'
-	//
-	//	The column of a: 1
-	//	The column of 𐐀: 2
-	//	The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
-	//
+	//  The column of a: 1
+	//  The column of 𐐀: 2
+	//  The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
 	// Optional.
 	Column        int32 `protobuf:"varint,2,opt,name=column,proto3" json:"column,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/service/bitbucket/annotator.go
+++ b/service/bitbucket/annotator.go
@@ -35,6 +35,7 @@ type ReportAnnotator struct {
 	owner, repo string
 
 	muAnnotations sync.Mutex
+	activeTool    string
 	// store annotations in map per tool name
 	// so we can create report per tool
 	comments map[string][]*reviewdog.Comment
@@ -92,50 +93,72 @@ func (r *ReportAnnotator) Post(_ context.Context, c *reviewdog.Comment) error {
 
 func (*ReportAnnotator) ShouldPrependGitRelDir() bool { return true }
 
+// SetTool selects the project runner whose results the next Flush call publishes.
+func (r *ReportAnnotator) SetTool(toolName, _ string) {
+	r.muAnnotations.Lock()
+	defer r.muAnnotations.Unlock()
+	r.activeTool = toolName
+}
+
 // Flush posts comments which has not been posted yet.
 func (r *ReportAnnotator) Flush(ctx context.Context) error {
 	r.muAnnotations.Lock()
 	defer r.muAnnotations.Unlock()
-	defer func() { r.comments = nil }()
+	defer func() {
+		r.comments = make(map[string][]*reviewdog.Comment)
+		r.activeTool = ""
+	}()
+
+	if r.activeTool != "" {
+		return r.flushTool(ctx, r.activeTool, r.comments[r.activeTool])
+	}
 
 	// create/update/annotate report per tool
 	for tool, comments := range r.comments {
-		reportID := reportID(tool, reporter)
-		title := reportTitle(tool, reporter)
-		if len(comments) == 0 {
-			// if no annotation, create Passed report
-			if err := r.createOrUpdateReport(ctx, reportID, title, reportResultPassed); err != nil {
-				return err
-			}
-			// and move one
-			continue
-		}
-
-		// create report or update report first, with the failed status
-		if err := r.createOrUpdateReport(ctx, reportID, title, reportResultFailed); err != nil {
+		if err := r.flushTool(ctx, tool, comments); err != nil {
 			return err
 		}
+	}
 
-		// send comments in batches, because of the api max payload size limit
-		for start, annCount := 0, len(comments); start < annCount; start += annotationsBatchSize {
-			end := start + annotationsBatchSize
+	return nil
+}
 
-			if end > annCount {
-				end = annCount
-			}
+func (r *ReportAnnotator) flushTool(
+	ctx context.Context,
+	tool string,
+	comments []*reviewdog.Comment,
+) error {
+	reportID := reportID(tool, reporter)
+	title := reportTitle(tool, reporter)
+	if len(comments) == 0 {
+		// if no annotation, create Passed report
+		return r.createOrUpdateReport(ctx, reportID, title, reportResultPassed)
+	}
 
-			req := &AnnotationsRequest{
-				Owner:      r.owner,
-				Repository: r.repo,
-				Commit:     r.sha,
-				ReportID:   reportID,
-				Comments:   comments[start:end],
-			}
+	// create report or update report first, with the failed status
+	if err := r.createOrUpdateReport(ctx, reportID, title, reportResultFailed); err != nil {
+		return err
+	}
 
-			err := r.cli.CreateOrUpdateAnnotations(ctx, req)
-			if err != nil {
-				return fmt.Errorf("failed to post annotations: %w", err)
-			}
+	// send comments in batches, because of the api max payload size limit
+	for start, annCount := 0, len(comments); start < annCount; start += annotationsBatchSize {
+		end := start + annotationsBatchSize
+
+		if end > annCount {
+			end = annCount
+		}
+
+		req := &AnnotationsRequest{
+			Owner:      r.owner,
+			Repository: r.repo,
+			Commit:     r.sha,
+			ReportID:   reportID,
+			Comments:   comments[start:end],
+		}
+
+		err := r.cli.CreateOrUpdateAnnotations(ctx, req)
+		if err != nil {
+			return fmt.Errorf("failed to post annotations: %w", err)
 		}
 	}
 

--- a/service/bitbucket/annotator_test.go
+++ b/service/bitbucket/annotator_test.go
@@ -72,6 +72,26 @@ func (s *AnnotatorTestSuite) TestOneComment() {
 	s.cli.AssertExpectations(s.T())
 }
 
+// Project mode flushes once for every runner. A completed runner must not
+// discard the annotation buffer needed by the runner that follows it.
+func (s *AnnotatorTestSuite) TestFlushesProjectRunnersIndependently() {
+	runners := []string{"runner1", "runner2"}
+	ctx, annotator := s.createAnnotator(runners)
+
+	annotator.SetTool(runners[0], "")
+	s.assumeReportCreated(ctx, runners[0], reportResultPassed)
+	s.Require().NoError(annotator.Flush(ctx))
+
+	comment := s.buildComment(runners[1], 1)
+	annotator.SetTool(runners[1], "")
+	s.assumeReportCreated(ctx, runners[1], reportResultFailed)
+	s.assumeAnnotationsCreated(ctx, runners[1], []*reviewdog.Comment{comment})
+	s.Require().NoError(annotator.Post(ctx, comment))
+	s.Require().NoError(annotator.Flush(ctx))
+
+	s.cli.AssertExpectations(s.T())
+}
+
 // Predefined runners list, and duplicated comment
 func (s *AnnotatorTestSuite) TestDuplicateComments() {
 	runners := []string{"runner1", "runner2"}


### PR DESCRIPTION
## Summary

- Publish each Bitbucket project runner when that runner finishes.
- Reinitialize the annotation buffer after every flush so later runners can add annotations.
- Add regression coverage for a clean runner followed by a runner with diagnostics.

Fixes #2203

## Testing

- `go test ./service/bitbucket`
- `go test ./...`