### PR TITLE
fix: skip diff lookup without diagnostics

### DIFF
--- a/proto/rdf/reviewdog.pb.go
+++ b/proto/rdf/reviewdog.pb.go
@@ -450,11 +450,9 @@ type Position struct {
 	Line int32 `protobuf:"varint,1,opt,name=line,proto3" json:"line,omitempty"`
 	// Column number, starting at 1 (byte count in UTF-8).
 	// Example: 'a𐐀b'
-	//
-	//	The column of a: 1
-	//	The column of 𐐀: 2
-	//	The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
-	//
+	//  The column of a: 1
+	//  The column of 𐐀: 2
+	//  The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
 	// Optional.
 	Column        int32 `protobuf:"varint,2,opt,name=column,proto3" json:"column,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/reviewdog.go
+++ b/reviewdog.go
@@ -139,6 +139,9 @@ func (w *Reviewdog) Run(ctx context.Context, r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("parse error: %w", err)
 	}
+	if len(results) == 0 {
+		return nil
+	}
 
 	d, err := w.d.Diff(ctx)
 	if err != nil {

--- a/reviewdog_test.go
+++ b/reviewdog_test.go
@@ -2,6 +2,7 @@ package reviewdog
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -24,6 +25,50 @@ func (s *testWriter) Post(_ context.Context, c *Comment) error {
 }
 
 func (s *testWriter) ShouldPrependGitRelDir() bool { return s.shouldPrependGitRelDir }
+
+type errorDiffService struct {
+	called bool
+}
+
+func (s *errorDiffService) Diff(context.Context) ([]byte, error) {
+	s.called = true
+	return nil, errors.New("unexpected diff request")
+}
+
+func (*errorDiffService) Strip() int { return 0 }
+
+type testBulkWriter struct {
+	testWriter
+	flushed bool
+}
+
+func (s *testBulkWriter) Flush(context.Context) error {
+	s.flushed = true
+	return nil
+}
+
+func TestReviewdog_Run_skips_remote_work_without_diagnostics(t *testing.T) {
+	efm, err := errorformat.NewErrorformat([]string{`%f:%l:%c: %m`})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diffService := &errorDiffService{}
+	comments := &testBulkWriter{
+		testWriter: testWriter{FakePost: func(*Comment) error { return nil }},
+	}
+	app := NewReviewdog("tool name", parser.NewErrorformatParser(efm), comments, diffService, filter.ModeAdded, FailLevelDefault)
+
+	if err := app.Run(context.Background(), strings.NewReader("")); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if diffService.called {
+		t.Error("Run() requested a diff without diagnostics")
+	}
+	if comments.flushed {
+		t.Error("Run() flushed comments without diagnostics")
+	}
+}
 
 func ExampleReviewdog() {
 	difftext := `diff --git a/golint.old.go b/golint.new.go


### PR DESCRIPTION
## Summary
- Skip diff retrieval when a linter produces no diagnostics.
- Avoid flushing remote reporters when there is nothing to report.
- Add regression coverage for the no-diagnostics path.

Fixes #2174

## Testing
- go test .
- go test ./...