### PR TITLE
fix: preserve blank GitHub suggestions

### DIFF
--- a/proto/rdf/reviewdog.pb.go
+++ b/proto/rdf/reviewdog.pb.go
@@ -450,11 +450,9 @@ type Position struct {
 	Line int32 `protobuf:"varint,1,opt,name=line,proto3" json:"line,omitempty"`
 	// Column number, starting at 1 (byte count in UTF-8).
 	// Example: 'a𐐀b'
-	//
-	//	The column of a: 1
-	//	The column of 𐐀: 2
-	//	The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
-	//
+	//  The column of a: 1
+	//  The column of 𐐀: 2
+	//  The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
 	// Optional.
 	Column        int32 `protobuf:"varint,2,opt,name=column,proto3" json:"column,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/service/github/github.go
+++ b/service/github/github.go
@@ -501,6 +501,10 @@ func buildSingleSuggestion(c *reviewdog.Comment, s *rdf.Suggestion) (string, err
 	if txt != "" {
 		sb.WriteString(txt)
 		sb.WriteString("\n")
+	} else if sourceLine, ok := c.Result.SourceLines[startLine]; ok && sourceLine == "" {
+		// A blank line in the pull request must remain a blank replacement.
+		// Without this line GitHub treats the suggestion as a deletion.
+		sb.WriteString("\n")
 	}
 	commentutil.WriteCodeFence(&sb, backticks)
 	return sb.String(), nil

--- a/service/github/github_test.go
+++ b/service/github/github_test.go
@@ -40,6 +40,27 @@ func setupGitHubClient() *github.Client {
 	return client
 }
 
+func TestBuildSingleSuggestionPreservesBlankLine(t *testing.T) {
+	c := &reviewdog.Comment{
+		Result: &filter.FilteredDiagnostic{
+			Diagnostic: &rdf.Diagnostic{
+				Location: &rdf.Location{Range: &rdf.Range{Start: &rdf.Position{Line: 15}}},
+			},
+			SourceLines: map[int]string{15: ""},
+		},
+	}
+	s := &rdf.Suggestion{Range: &rdf.Range{Start: &rdf.Position{Line: 15}}}
+
+	got, err := buildSingleSuggestion(c, s)
+	if err != nil {
+		t.Fatalf("buildSingleSuggestion() error = %v", err)
+	}
+	const want = "```suggestion\n\n```"
+	if got != want {
+		t.Errorf("buildSingleSuggestion() = %q, want %q", got, want)
+	}
+}
+
 func setupEnvs() (cleanup func()) {
 	var cleanEnvs = []string{
 		"GITHUB_ACTIONS",


### PR DESCRIPTION
## Summary

- Preserve blank replacement lines when rendering GitHub suggestions.
- Keep empty suggestions as deletions when the replacement line is absent.
- Add regression coverage for trailing-whitespace fixes on blank lines.

## Testing

- `go test ./service/github`
- `go test ./...`