### PR TITLE
fix: log diagnostic filter summary at debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :sparkles: Release Note <!-- optional -->
 
 ### :rocket: Enhancements
+- [#2153](https://github.com/reviewdog/reviewdog/issues/2153) Log diagnostic filtering counts at debug level so fully filtered input is visible
 - [#2257](https://github.com/reviewdog/reviewdog/pull/2257) Use -trimpath flag for reproducible build
 - [#2513](https://github.com/reviewdog/reviewdog/pull/2513) Drop support of windows/arm
 - [#2543](https://github.com/reviewdog/reviewdog/pull/2543) Update `gitlab-mr-discussion` reporter to embed a fingerprint meta-comment in each posted note and automatically resolve previously-posted discussions whose diagnostic is no longer reported (fixes [#1150](https://github.com/reviewdog/reviewdog/issues/1150)).

--- a/reviewdog.go
+++ b/reviewdog.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/reviewdog/reviewdog/diff"
@@ -97,6 +98,19 @@ func (w *Reviewdog) runFromResult(ctx context.Context, results []*rdf.Diagnostic
 	pathutil.NormalizePathInResults(results, wd, relDir)
 
 	checks := filter.FilterCheck(results, filediffs, strip, wd, w.filterMode)
+	reportable := 0
+	for _, check := range checks {
+		if check.ShouldReport {
+			reportable++
+		}
+	}
+	slog.DebugContext(ctx, "reviewdog: filter summary",
+		"tool", w.toolname,
+		"filter-mode", w.filterMode.String(),
+		"diagnostics", len(checks),
+		"reportable", reportable,
+		"filtered", len(checks)-reportable,
+	)
 	shouldFail := false
 
 	for _, check := range checks {

--- a/reviewdog_test.go
+++ b/reviewdog_test.go
@@ -1,7 +1,9 @@
 package reviewdog
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -101,6 +103,47 @@ index 34cacb9..a727dd3 100644
 	d := NewDiffString(difftext, 1)
 	app := NewReviewdog("tool name", p, c, d, filter.ModeAdded, FailLevelDefault)
 	app.Run(context.Background(), strings.NewReader(lintresult))
+}
+
+func TestReviewdog_Run_logs_filter_summary(t *testing.T) {
+	defaultLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(defaultLogger) })
+
+	var logs bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	c := &testWriter{
+		FakePost: func(*Comment) error {
+			t.Fatal("filtered diagnostic should not be posted")
+			return nil
+		},
+	}
+	efm, _ := errorformat.NewErrorformat([]string{`%f:%l:%c: %m`})
+	app := NewReviewdog(
+		"tool name",
+		parser.NewErrorformatParser(efm),
+		c,
+		NewDiffString("", 1),
+		filter.ModeAdded,
+		FailLevelDefault,
+	)
+
+	if err := app.Run(context.Background(), strings.NewReader("outside.go:1:1: message\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		`msg="reviewdog: filter summary"`,
+		`tool="tool name"`,
+		`filter-mode=added`,
+		`diagnostics=1`,
+		`reportable=0`,
+		`filtered=1`,
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Errorf("debug log %q does not contain %q", logs.String(), want)
+		}
+	}
 }
 
 func TestReviewdog_Run_git_rel_dir(t *testing.T) {


### PR DESCRIPTION
- [x] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

Closes #2153

## Changes

- Emit one structured debug summary after diagnostic filtering with the tool, filter mode, and total, reportable, and filtered counts.
- Keep default and info-level output unchanged and avoid logging diagnostic text, paths, or source content.
- Add a regression test for non-empty input where every diagnostic is filtered and no comment is posted.

## Verification

- `go test . -run TestReviewdog_Run_logs_filter_summary -count=1`
- `go test .`
- `go test -v -race -coverpkg=./... -coverprofile=coverage.txt ./...`
- CLI smoke test with one diagnostic and an empty diff

Generated with OpenAI Codex. The change has not been independently human-reviewed.
