### PR TITLE
re-generate proto/rdf/reviewdog.pb.go

### DIFF
--- a/proto/rdf/reviewdog.pb.go
+++ b/proto/rdf/reviewdog.pb.go
@@ -450,11 +450,9 @@ type Position struct {
 	Line int32 `protobuf:"varint,1,opt,name=line,proto3" json:"line,omitempty"`
 	// Column number, starting at 1 (byte count in UTF-8).
 	// Example: 'a𐐀b'
-	//
-	//	The column of a: 1
-	//	The column of 𐐀: 2
-	//	The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
-	//
+	//  The column of a: 1
+	//  The column of 𐐀: 2
+	//  The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
 	// Optional.
 	Column        int32 `protobuf:"varint,2,opt,name=column,proto3" json:"column,omitempty"`
 	unknownFields protoimpl.UnknownFields


### PR DESCRIPTION
This will fix the failure of <https://github.com/reviewdog/reviewdog/actions/workflows/rdformat.yml>.

> ```plain
> diff --git a/proto/rdf/reviewdog.pb.go b/proto/rdf/reviewdog.pb.go
> index 4ec6cbf..84feafb 100644
> --- a/proto/rdf/reviewdog.pb.go
> +++ b/proto/rdf/reviewdog.pb.go
> @@ -450,11 +450,9 @@ type Position struct {
>  	Line int32 `protobuf:"varint,1,opt,name=line,proto3" json:"line,omitempty"`
>  	// Column number, starting at 1 (byte count in UTF-8).
>  	// Example: 'a𐐀b'
> -	//
> -	//	The column of a: 1
> -	//	The column of 𐐀: 2
> -	//	The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
> -	//
> +	//  The column of a: 1
> +	//  The column of 𐐀: 2
> +	//  The column of b: 6 since 𐐀 is represented with 4 bytes in UTF-8.
>  	// Optional.
>  	Column        int32 `protobuf:"varint,2,opt,name=column,proto3" json:"column,omitempty"`
>  	unknownFields protoimpl.UnknownFields
> Error: Process completed with exit code 1.
> ```
> 
> https://github.com/reviewdog/reviewdog/actions/runs/34434927202/job/102737900147